### PR TITLE
add metadata properties to specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,9 +29,9 @@ else
 
   case ENV['RAILS_VERSION']
   when /^4.2/
+    gem 'coffee-rails', '~> 4.1.0'
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
   when /^4.[01]/
     gem 'sass-rails', '< 5.0'
   end

--- a/spec/model_shared.rb
+++ b/spec/model_shared.rb
@@ -1,69 +1,72 @@
 # Shared Model
 RSpec.shared_examples 'a persistent work type' do
-  before(:all) do
-    @work = described_class.new
-    @cls = described_class
+  let(:work) { described_class.new }
+  let(:cls) { described_class }
+
+  describe 'class membership' do
+    it 'has correct instance type' do
+      expect(work).to be_an_instance_of(cls)
+    end
+
+    it 'initially has nil id' do
+      expect(work.id).to be_nil
+    end
   end
 
-  it 'is correct instance type' do
-    expect(@work).to be_an_instance_of(@cls)
-  end
-  it 'sets title' do
-    @work.title = ['San Diego Evening Tribune']
-  end
-  it 'initially has nil id' do
-    expect(@work.id).to be_nil
-  end
-  it 'saves' do
-    @work.save
-  end
-  it 'has non-nil id after save' do
-    expect(@work.id).to_not be_nil
-  end
-  it 'appears to be persisted in fcrepo' do
-    expect(@cls.all.map { |w| w.id }).to include(@work.id)
-  end
-  it 'deletes via delete' do
-    @work.delete
-    expect(@cls.all.map { |w| w.id }).to_not include(@work.id)
+  describe 'object persistence' do
+    before do
+      work.title = ['San Diego Evening Tribune']
+      work.save!
+    end
+
+    it 'has non-nil id after save' do
+      expect(work.id).not_to be_nil
+    end
+
+    it 'appears to be persisted in fcrepo' do
+      expect(cls.all.map(&:id)).to include(work.id)
+    end
+
+    describe 'deletion' do
+      it 'deletes via delete' do
+        work.delete
+        expect(cls.all.map(&:id)).not_to include(work.id)
+      end
+    end
   end
 end
 
 RSpec.shared_examples 'a PCDM file set' do
-  before(:all) do
-    @work = described_class.new
-    @cls = described_class
-  end
+  let(:work) { described_class.new }
+  let(:cls) { described_class }
 
   it 'looks like a fileset by method introspection' do
-    expect(@work.file_set?).to be true
+    expect(work.file_set?).to be true
   end
 
   it 'does not look like a work' do
-    expect(@work.work?).to be false
+    expect(work.work?).to be false
   end
 
   it 'still looks like a PCDM object, though' do
-    expect(@work.pcdm_object?).to be true
+    expect(work.pcdm_object?).to be true
   end
 end
 
 RSpec.shared_examples 'a work and PCDM object' do
-  before(:all) do
-    @work = described_class.new
-    @cls = described_class
-  end
+  let(:work) { described_class.new }
+  let(:cls) { described_class }
 
   it 'looks like a work' do
-    expect(@work.work?).to be true
+    expect(work.work?).to be true
   end
 
   it 'also looks like a PCDM object' do
-    expect(@work.pcdm_object?).to be true
+    expect(work.pcdm_object?).to be true
   end
 
   it 'does not look like a fileset' do
-    expect(@work.file_set?).to be false
+    expect(work.file_set?).to be false
   end
 end
 
@@ -102,28 +105,18 @@ def model_fixtures(target_type)
 
   # save swarm, persist all the things!
   issue1.save
+  container.save
   publication.save
   page1.save
   page2.save
   article1.save
   article2.save
-  container.save
 
   # return types appropriate to target class: return correct starting point
   # for the object graph of these fixtures, in the context of their use.
-  if target_type == NewspaperTitle
-    return publication
-  end
-  if target_type == NewspaperIssue
-    return issue1
-  end
-  if target_type == NewspaperPage
-    return page1
-  end
-  if target_type == NewspaperArticle
-    return article2
-  end
-  if target_type == NewspaperContainer
-    return container
-  end
+  return publication if target_type == NewspaperTitle
+  return issue1 if target_type == NewspaperIssue
+  return page1 if target_type == NewspaperPage
+  return article2 if target_type == NewspaperArticle
+  return container if target_type == NewspaperContainer
 end

--- a/spec/models/newspaper_article_spec.rb
+++ b/spec/models/newspaper_article_spec.rb
@@ -4,28 +4,31 @@ require 'spec_helper'
 require 'model_shared'
 
 RSpec.describe NewspaperArticle do
-  before(:all) do
-    @fixture = model_fixtures(NewspaperArticle)
-  end
+  let(:fixture) { model_fixtures(described_class) }
 
   # shared behaviors
   it_behaves_like('a work and PCDM object')
   it_behaves_like('a persistent work type')
 
-  describe 'Model behaviors and properties' do
+  describe 'Metadata properties' do
     it 'has expected properties' do
-      properties = NewspaperArticle.properties
-      expect(properties.keys).to include 'section'
+      expect(fixture).to respond_to(:author)
+      expect(fixture).to respond_to(:photographer)
+      expect(fixture).to respond_to(:volume)
+      expect(fixture).to respond_to(:edition)
+      expect(fixture).to respond_to(:issue)
+      expect(fixture).to respond_to(:geographic_coverage)
+      expect(fixture).to respond_to(:extent)
     end
   end
 
   describe 'Relationship methods' do
     it 'has expected test fixture' do
-      expect(@fixture).to be_an_instance_of(NewspaperArticle)
+      expect(fixture).to be_an_instance_of(described_class)
     end
 
     it 'can get aggregated pages' do
-      pages = @fixture.pages
+      pages = fixture.pages
       expect(pages).to be_an_instance_of(Array)
       expect(pages.length).to be > 0
       pages.each do |e|
@@ -34,17 +37,17 @@ RSpec.describe NewspaperArticle do
     end
 
     it 'can get aggregating issue' do
-      issue = @fixture.issue
+      issue = fixture.issue
       expect(issue).to be_an_instance_of(NewspaperIssue)
     end
 
     it 'can get publicaiton (transitive)' do
-      publication = @fixture.publication
+      publication = fixture.publication
       expect(publication).to be_an_instance_of(NewspaperTitle)
     end
 
     it 'can get aggregating containers (transitive)' do
-      containers = @fixture.containers
+      containers = fixture.containers
       expect(containers).to be_an_instance_of(Array)
       expect(containers.length).to be > 0
       containers.each do |e|

--- a/spec/models/newspaper_container_spec.rb
+++ b/spec/models/newspaper_container_spec.rb
@@ -4,7 +4,38 @@ require 'spec_helper'
 require 'model_shared'
 
 RSpec.describe NewspaperContainer do
+  let(:fixture) { model_fixtures(described_class) }
+
   # shared behaviors
   it_behaves_like('a work and PCDM object')
   it_behaves_like('a persistent work type')
+
+  describe "Metadata properties" do
+    it "has expected properties" do
+      expect(fixture).to respond_to(:extent)
+    end
+  end
+
+  describe "Relationship methods" do
+    it "has expected test fixture" do
+      expect(fixture).to be_an_instance_of(described_class)
+    end
+
+    it "can get aggregating publication/title" do
+      parent = fixture.publication
+      expect(parent).not_to be_nil
+      expect(parent).to be_an_instance_of(NewspaperTitle)
+      # reciprocity and round-trip
+      expect(parent.containers).to include fixture
+    end
+
+    it "can get aggregated pages" do
+      contained_pages = fixture.pages
+      expect(contained_pages).to be_an_instance_of(Array)
+      expect(contained_pages.length).to be > 0
+      contained_pages.each do |e|
+        expect(e).to be_an_instance_of(NewspaperPage)
+      end
+    end
+  end
 end

--- a/spec/models/newspaper_issue_spec.rb
+++ b/spec/models/newspaper_issue_spec.rb
@@ -4,37 +4,34 @@ require 'spec_helper'
 require 'model_shared'
 
 RSpec.describe NewspaperIssue do
-  before(:all) do
-    @fixture = model_fixtures(NewspaperIssue)
-  end
+  let(:fixture) { model_fixtures(described_class) }
 
   # shared behaviors
   it_behaves_like('a work and PCDM object')
   it_behaves_like('a persistent work type')
 
-  describe 'Model behaviors and properties' do
+  describe 'Metadata properties' do
     it 'has expected properties' do
-      properties = NewspaperIssue.properties
-      expect(properties.keys).to include 'alternative_title'
-      expect(properties.keys).to include 'edition'
+      expect(fixture).to respond_to(:edition)
+      expect(fixture).to respond_to(:extent)
     end
   end
 
   describe 'Relationship methods' do
     it 'has expected test fixture' do
-      expect(@fixture).to be_an_instance_of(NewspaperIssue)
+      expect(fixture).to be_an_instance_of(described_class)
     end
 
     it 'can get aggregating publication/title' do
-      parent = @fixture.publication
-      expect(parent).to_not be_nil
+      parent = fixture.publication
+      expect(parent).not_to be_nil
       expect(parent).to be_an_instance_of(NewspaperTitle)
       # reciprocity and round-trip
-      expect(parent.issues).to include @fixture
+      expect(parent.issues).to include fixture
     end
 
     it 'can get aggregated pages' do
-      contained_pages = @fixture.pages
+      contained_pages = fixture.pages
       expect(contained_pages).to be_an_instance_of(Array)
       expect(contained_pages.length).to be > 0
       contained_pages.each do |e|
@@ -43,7 +40,7 @@ RSpec.describe NewspaperIssue do
     end
 
     it 'can get aggregated articles' do
-      contained_articles = @fixture.articles
+      contained_articles = fixture.articles
       expect(contained_articles).to be_an_instance_of(Array)
       expect(contained_articles.length).to be > 0
       contained_articles.each do |e|

--- a/spec/models/newspaper_page_spec.rb
+++ b/spec/models/newspaper_page_spec.rb
@@ -4,20 +4,18 @@ require 'spec_helper'
 require 'model_shared'
 
 RSpec.describe NewspaperPage do
-  before(:all) do
-    @fixture = model_fixtures(NewspaperPage)
-  end
+  let(:fixture) { model_fixtures(described_class) }
 
   it_behaves_like('a work and PCDM object')
   it_behaves_like('a persistent work type')
 
   describe 'Relationship methods' do
     it 'has expected test fixture' do
-      expect(@fixture).to be_an_instance_of(NewspaperPage)
+      expect(fixture).to be_an_instance_of(described_class)
     end
 
     it 'can get aggregating articles for page' do
-      articles = @fixture.articles
+      articles = fixture.articles
       expect(articles).to be_an_instance_of(Array)
       expect(articles.length).to be > 0
       articles.each do |e|
@@ -26,7 +24,7 @@ RSpec.describe NewspaperPage do
     end
 
     it 'can get aggregating issues for page' do
-      issues = @fixture.issues
+      issues = fixture.issues
       expect(issues).to be_an_instance_of(Array)
       expect(issues.length).to be > 0
       issues.each do |e|
@@ -35,7 +33,7 @@ RSpec.describe NewspaperPage do
     end
 
     it 'can get aggregating containers for page' do
-      containers = @fixture.containers
+      containers = fixture.containers
       expect(containers).to be_an_instance_of(Array)
       expect(containers.length).to be > 0
       containers.each do |e|
@@ -44,8 +42,8 @@ RSpec.describe NewspaperPage do
     end
 
     it 'can get publication (transitive)' do
-      publication = @fixture.publication
-      expect(publication).to_not be_nil
+      publication = fixture.publication
+      expect(publication).not_to be_nil
       expect(publication).to be_an_instance_of(NewspaperTitle)
     end
   end

--- a/spec/models/newspaper_title_spec.rb
+++ b/spec/models/newspaper_title_spec.rb
@@ -4,28 +4,28 @@ require 'spec_helper'
 require 'model_shared'
 
 RSpec.describe NewspaperTitle do
-  before(:all) do
-    @fixture = model_fixtures(NewspaperTitle)
-  end
+  let(:fixture) { model_fixtures(described_class) }
 
   # shared behaviors
   it_behaves_like('a work and PCDM object')
   it_behaves_like('a persistent work type')
 
-  describe 'Model behaviors and properties' do
+  describe 'Metadata and properties' do
     it 'class has expected properties' do
-      properties = NewspaperTitle.properties
-      expect(properties.keys).to include 'alternative_title'
+      expect(fixture).to respond_to(:edition)
+      expect(fixture).to respond_to(:frequency)
+      expect(fixture).to respond_to(:preceded_by)
+      expect(fixture).to respond_to(:succeeded_by)
     end
   end
 
   describe 'Relationship methods' do
     it 'has expected test fixture' do
-      expect(@fixture).to be_an_instance_of(NewspaperTitle)
+      expect(fixture).to be_an_instance_of(described_class)
     end
 
     it 'can get issues' do
-      issues = @fixture.issues
+      issues = fixture.issues
       expect(issues).to be_an_instance_of(Array)
       # our test fixture is non-empty
       expect(issues.length).to be > 0
@@ -36,7 +36,7 @@ RSpec.describe NewspaperTitle do
   end
 
   it 'can get containers' do
-    containers = @fixture.containers
+    containers = fixture.containers
     expect(containers).to be_an_instance_of(Array)
     expect(containers.length).to be > 0
     containers.each do |e|

--- a/spec/models/newspaper_works/newspaper_core_metadata_spec.rb
+++ b/spec/models/newspaper_works/newspaper_core_metadata_spec.rb
@@ -1,39 +1,40 @@
 # Core Metadata Spec Tests
-RSpec.describe 'NewspaperCoreMetadata' do
-  before do
-    class NewspaperishWork < ActiveFedora::Base
-      include ::Hyrax::WorkBehavior
-      include NewspaperWorks::NewspaperCoreMetadata
-      include ::Hyrax::BasicMetadata
-    end
+RSpec.describe NewspaperWorks::NewspaperCoreMetadata do
+  class NewspaperishWork < ActiveFedora::Base
+    include ::Hyrax::WorkBehavior
+    include NewspaperWorks::NewspaperCoreMetadata
+    include ::Hyrax::BasicMetadata
   end
 
+  let(:work) { NewspaperishWork.new }
+
   it 'creates work using mixin' do
-    work = NewspaperishWork.new
     expect(work).to be_an_instance_of(NewspaperishWork)
   end
 
   it 'has expected properties' do
-    properties = NewspaperishWork.properties
-    expect(properties.keys).to include 'genre'
-    expect(properties.keys).to include 'held_by'
-    expect(properties.keys).to include 'issued'
-    expect(properties.keys).to include 'place_of_publication'
+    expect(work).to respond_to(:alternative_title)
+    expect(work).to respond_to(:genre)
+    expect(work).to respond_to(:issued)
+    expect(work).to respond_to(:place_of_publication)
+    expect(work).to respond_to(:issn)
+    expect(work).to respond_to(:lccn)
+    expect(work).to respond_to(:oclcnum)
+    expect(work).to respond_to(:held_by)
   end
 
   it 'work can set/get properties' do
-    work = NewspaperishWork.new
-    work.genre = ['http://cv.iptc.org/newscodes/genre/Opinion']
-    expect(work.genre).to include 'http://cv.iptc.org/newscodes/genre/Opinion'
+    genre_uri = 'http://cv.iptc.org/newscodes/genre/Opinion'
+    work.genre = [genre_uri]
+    expect(work.genre).to include genre_uri
   end
 
   it 'work using mixin saves' do
-    work = NewspaperishWork.new
     work.place_of_publication = ['http://www.geonames.org/5780993/about.rdf']
     work.genre = ['http://cv.iptc.org/newscodes/genre/Opinion']
     expect(work.id).to be_nil
     work.save!
-    expect(work.id).to_not be_nil
-    expect(NewspaperishWork.all.map { |w| w.id }).to include(work.id)
+    expect(work.id).not_to be_nil
+    expect(NewspaperishWork.all.map(&:id)).to include(work.id)
   end
 end

--- a/spec/models/newspaper_works/scanned_media_metadata_spec.rb
+++ b/spec/models/newspaper_works/scanned_media_metadata_spec.rb
@@ -1,37 +1,33 @@
 # Scanned Media Metada Spec Tests
-RSpec.describe 'ScannedMediaMetadata' do
-  before do
-    class ScannedMediaWork < ActiveFedora::Base
-      include ::Hyrax::WorkBehavior
-      include NewspaperWorks::ScannedMediaMetadata
-      include ::Hyrax::BasicMetadata
-    end
+RSpec.describe NewspaperWorks::ScannedMediaMetadata do
+  class ScannedMediaWork < ActiveFedora::Base
+    include ::Hyrax::WorkBehavior
+    include NewspaperWorks::ScannedMediaMetadata
+    include ::Hyrax::BasicMetadata
   end
 
+  let(:work) { ScannedMediaWork.new }
+
   it 'creates work using mixin' do
-    work = ScannedMediaWork.new
     expect(work).to be_an_instance_of(ScannedMediaWork)
   end
 
   it 'has expected properties' do
-    properties = ScannedMediaWork.properties
-    expect(properties.keys).to include 'text_direction'
-    expect(properties.keys).to include 'pagination'
-    expect(properties.keys).to include 'section'
+    expect(work).to respond_to(:text_direction)
+    expect(work).to respond_to(:pagination)
+    expect(work).to respond_to(:section)
   end
 
   it 'work can set/get properties' do
-    work = ScannedMediaWork.new
     work.section = 'foo'
     expect(work.section).to include 'foo'
   end
 
   it 'work using mixin saves' do
-    work = ScannedMediaWork.new
     work.title = ['label able label']
     expect(work.id).to be_nil
     work.save!
-    expect(work.id).to_not be_nil
-    expect(ScannedMediaWork.all.map { |w| w.id }).to include(work.id)
+    expect(work.id).not_to be_nil
+    expect(ScannedMediaWork.all.map(&:id)).to include(work.id)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,7 +98,7 @@ module SuccinctFormatterOverrides
   def dump_pending(_) end
 end
 
-if ENV['SUPPRESS_PENDING'] != nil
+unless ENV['SUPPRESS_PENDING'].nil?
   RSpec::Core::Formatters::DocumentationFormatter.prepend SuccinctFormatterOverrides
   RSpec::Core::Formatters::ProgressFormatter.prepend SuccinctFormatterOverrides
 end


### PR DESCRIPTION
This PR adds tests for all metadata properties to the specs for the model classes.

Also lots of Rubocop cleanup, gets us down to about 34 offenses.

Should allow us to close https://github.com/marriott-library/newspaper_works/issues/7.