### PR TITLE
Some metadata fields not indexed in solr

### DIFF
--- a/app/forms/hyrax/newspaper_article_form.rb
+++ b/app/forms/hyrax/newspaper_article_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class NewspaperArticleForm < ::NewspaperWorks::NewspaperCoreFormData
     self.model_class = ::NewspaperArticle
     self.terms += [:alternative_title, :author, :photographer, :volume,
-                   :edition, :issue, :geographic_coverage, :extent,
+                   :edition, :issue_number, :geographic_coverage, :extent,
                    :page_number, :section]
   end
 end

--- a/app/forms/hyrax/newspaper_issue_form.rb
+++ b/app/forms/hyrax/newspaper_issue_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   # Newspaper Issue Form Class
   class NewspaperIssueForm < ::NewspaperWorks::NewspaperCoreFormData
     self.model_class = ::NewspaperIssue
-    self.terms += [:alternative_title, :volume, :edition, :issue, :extent]
+    self.terms += [:alternative_title, :volume, :edition, :issue_number, :extent]
     self.terms -= [:creator, :contributor, :description, :subject]
   end
 end

--- a/app/indexers/newspaper_works/newspaper_core_indexer.rb
+++ b/app/indexers/newspaper_works/newspaper_core_indexer.rb
@@ -3,7 +3,7 @@ module NewspaperWorks
   class NewspaperCoreIndexer < Hyrax::WorkIndexer
     # This indexes the default metadata. You can remove it if you want to
     # provide your own metadata and indexing.
-    # include Hyrax::IndexesBasicMetadata
+    include Hyrax::IndexesBasicMetadata
 
     # Fetch remote labels for based_near. You can remove this if you don't want
     # this behavior

--- a/app/models/newspaper_article.rb
+++ b/app/models/newspaper_article.rb
@@ -76,7 +76,7 @@ class NewspaperArticle < ActiveFedora::Base
 
   # - Issue
   property(
-    :issue,
+    :issue_number,
     predicate: ::RDF::Vocab::BIBO.issue,
     multiple: false
   ) do |index|

--- a/app/models/newspaper_issue.rb
+++ b/app/models/newspaper_issue.rb
@@ -52,7 +52,7 @@ class NewspaperIssue < ActiveFedora::Base
 
   #  - Issue
   property(
-    :issue,
+    :issue_number,
     predicate: ::RDF::Vocab::BIBO.issue,
     multiple: false
   ) do |index|

--- a/spec/forms/hyrax/newspaper_article_form_spec.rb
+++ b/spec/forms/hyrax/newspaper_article_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::NewspaperArticleForm do
                           :rights_statement, :publisher, :subject, :identifier,
                           :publication_date, :place_of_publication, :issn,
                           :lccn, :oclcnum, :alternative_title, :author,
-                          :photographer, :volume, :edition, :issue,
+                          :photographer, :volume, :edition, :issue_number,
                           :geographic_coverage, :extent, :page_number,
                           :section])
     end

--- a/spec/forms/hyrax/newspaper_issue_form_spec.rb
+++ b/spec/forms/hyrax/newspaper_issue_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::NewspaperIssueForm do
       is_expected.to eq ([:license, :rights_statement, :publisher, :identifier,
                           :publication_date, :place_of_publication, :issn,
                           :lccn, :oclcnum, :alternative_title, :volume,
-                          :edition, :issue, :extent])
+                          :edition, :issue_number, :extent])
     end
   end
 end

--- a/spec/models/newspaper_article_spec.rb
+++ b/spec/models/newspaper_article_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NewspaperArticle do
       expect(fixture).to respond_to(:photographer)
       expect(fixture).to respond_to(:volume)
       expect(fixture).to respond_to(:edition)
-      expect(fixture).to respond_to(:issue)
+      expect(fixture).to respond_to(:issue_number)
       expect(fixture).to respond_to(:geographic_coverage)
       expect(fixture).to respond_to(:extent)
     end

--- a/spec/models/newspaper_issue_spec.rb
+++ b/spec/models/newspaper_issue_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe NewspaperIssue do
 
   describe 'Metadata properties' do
     it 'has expected properties' do
+      expect(fixture).to respond_to(:volume)
       expect(fixture).to respond_to(:edition)
+      expect(fixture).to respond_to(:issue_number)
       expect(fixture).to respond_to(:extent)
     end
   end


### PR DESCRIPTION
Minor update to allow basic metadata fields to be indexed in Solr. Had to rename the `issue` parameter in articles because it was conflicting with the `def issue` relationship method in the model.