### PR TITLE
Flattened JSON word coordinates

### DIFF
--- a/app/services/newspaper_works/text_extraction_derivative_service.rb
+++ b/app/services/newspaper_works/text_extraction_derivative_service.rb
@@ -12,10 +12,13 @@ module NewspaperWorks
       @alto_path = prepare_path('xml')
       # prepare destination directory for plain text (as .txt files):
       @txt_path = prepare_path('txt')
+      # prepare destination directory for flat JSON (as .json files):
+      @json_path = prepare_path('json')
       ocr = NewspaperWorks::TextExtraction::PageOCR.new(filename)
       # OCR will run once, on first method call to either .alto or .plain:
       write_plain_text(ocr.plain)
       write_alto(ocr.alto)
+      write_json(ocr.word_json)
     end
 
     def write_alto(xml)
@@ -30,9 +33,16 @@ module NewspaperWorks
       end
     end
 
+    def write_json(text)
+      File.open(@json_path, 'w') do |outfile|
+        outfile.write(text)
+      end
+    end
+
     def cleanup_derivatives
       super('txt')
       super('xml')
+      super('json')
     end
   end
 end

--- a/lib/newspaper_works/text_extraction/page_ocr.rb
+++ b/lib/newspaper_works/text_extraction/page_ocr.rb
@@ -44,6 +44,22 @@ module NewspaperWorks
         @words
       end
 
+      def normalized_coordinate(word)
+        {
+          word: word[:word],
+          height: (word[:y_end] - word[:y_start]),
+          width: (word[:x_end] - word[:x_start]),
+          x_start: word[:x_start].to_s,
+          y_start: word[:y_start].to_s
+        }
+      end
+
+      def word_json
+        save_words = words.map { |w| normalized_coordinate(w) }
+        payload = { words: save_words }
+        JSON.generate(payload)
+      end
+
       def plain
         load_box
         @plain

--- a/lib/newspaper_works/text_extraction/page_ocr.rb
+++ b/lib/newspaper_works/text_extraction/page_ocr.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'open3'
 require 'rtesseract'
 
@@ -47,10 +48,12 @@ module NewspaperWorks
       def normalized_coordinate(word)
         {
           word: word[:word],
-          height: (word[:y_end] - word[:y_start]),
-          width: (word[:x_end] - word[:x_start]),
-          x_start: word[:x_start].to_s,
-          y_start: word[:y_start].to_s
+          coordinates: [
+            word[:x_start],
+            word[:y_start],
+            (word[:x_end] - word[:x_start]),
+            (word[:y_end] - word[:y_start])
+          ]
         }
       end
 

--- a/spec/lib/newspaper_works/text_extraction/page_ocr_spec.rb
+++ b/spec/lib/newspaper_works/text_extraction/page_ocr_spec.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'nokogiri'
 require 'spec_helper'
 
@@ -68,6 +69,17 @@ RSpec.describe NewspaperWorks::TextExtraction::PageOCR do
       plain = ocr.plain
       expect(plain.class).to be String
       expect(plain.length).to be > 0
+    end
+  end
+
+  describe "JSON word coordinates" do
+    it "makes simple JSON word coordinates" do
+      ocr = described_class.new(example_gray_tiff)
+      parsed = JSON.parse(ocr.word_json)
+      expect(parsed['words'].length).to be > 1
+      word = ocr.words[0]
+      word1 = parsed['words'][0]
+      expect(word1['width']).to eq word[:x_end] - word[:x_start]
     end
   end
 end

--- a/spec/lib/newspaper_works/text_extraction/page_ocr_spec.rb
+++ b/spec/lib/newspaper_works/text_extraction/page_ocr_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe NewspaperWorks::TextExtraction::PageOCR do
       expect(parsed['words'].length).to be > 1
       word = ocr.words[0]
       word1 = parsed['words'][0]
-      expect(word1['width']).to eq word[:x_end] - word[:x_start]
+      expect(word1['coordinates'][2]).to eq word[:x_end] - word[:x_start]
+      expect(word1['coordinates'][3]).to eq word[:y_end] - word[:y_start]
     end
   end
 end

--- a/spec/services/newspaper_works/text_extraction_derivative_service_spec.rb
+++ b/spec/services/newspaper_works/text_extraction_derivative_service_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe NewspaperWorks::TextExtractionDerivativeService do
       altoxsd.validate(filename)
     end
 
+    def derivative_exists(ext)
+      path = expected_path(valid_file_set, ext)
+      expect(File.exist?(path)).to be true
+      expect(File.size(path)).to be > 0
+    end
+
     it "creates, stores valid ALTO and plain-text derivatives" do
       # these are in same test to avoid duplicate OCR operation
       service = described_class.new(valid_file_set)
@@ -39,9 +45,11 @@ RSpec.describe NewspaperWorks::TextExtractionDerivativeService do
       # ALTO derivative file exists at expected path and validates:
       altoxsd.validate(expected_path(valid_file_set, 'xml'))
       # Plain text exists as non-empty file:
-      txt_path = expected_path(valid_file_set, 'txt')
-      expect(File.exist?(txt_path)).to be true
-      expect(File.size(txt_path)).to be > 0
+      derivative_exists('txt')
+      derivative_exists('json')
+      json_path = expected_path(valid_file_set, 'json')
+      loaded_result = JSON.parse(File.read(json_path))
+      expect(loaded_result['words'].length).to be > 1
     end
   end
 end


### PR DESCRIPTION
These commits produce flattened JSON derivative containing word coordinate data, with each coordinate expressed as a hash containing the word and a four-member coordinates array.