### PR TITLE
add newspaper_works_fixtures dependency

### DIFF
--- a/newspaper_works.gemspec
+++ b/newspaper_works.gemspec
@@ -33,6 +33,7 @@ SUMMARY
   spec.add_development_dependency "factory_bot", '~> 4.4'
   spec.add_development_dependency "faraday"
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
+  spec.add_development_dependency 'newspaper_works_fixtures'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'solr_wrapper', '~> 2.0'


### PR DESCRIPTION
Adds a development dependency for the `newspaper_works_fixtures` gem so we can test batch ingest scripts against realistic content.