### PR TITLE
allow blank :place_of_publication field in add/edit form

### DIFF
--- a/app/models/concerns/newspaper_works/place_of_publication_behavior.rb
+++ b/app/models/concerns/newspaper_works/place_of_publication_behavior.rb
@@ -7,7 +7,9 @@ module NewspaperWorks
 
     included do
       self.controlled_properties = [:place_of_publication]
-      accepts_nested_attributes_for :place_of_publication, allow_destroy: true
+      accepts_nested_attributes_for :place_of_publication,
+                                    reject_if: proc { |attributes| attributes[:id].blank? },
+                                    allow_destroy: true
     end
   end
 end


### PR DESCRIPTION
This PR prevents save failures when the field is left blank in add/edit form.

Fixes #55.