### PR TITLE
Derivative attach queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ _More here soon!_
     be edited to make uploads optional for (all) work types, by setting
     `config.work_requires_files = false`.
 
+  * NewspaperWorks overrides Hyrax's default `:after_create_fileset` event
+    handler.  Because the Hyrax callback registry only allows single
+    subscribers to any event, application developers who overwrite
+    this handler, or integrate other gems that do likewise, must take care
+    to create a custom composition that ensures all work and queued jobs
+    desired run after this object lifecycle event.
+
 ## Development and Testing with Vagrant
 * clone samvera-vagrant
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ _More here soon!_
     `config.work_requires_files = false`.
 
   * NewspaperWorks overrides Hyrax's default `:after_create_fileset` event
-    handler.  Because the Hyrax callback registry only allows single
+    handler, in order to attach pre-existing derivatives in some ingest
+    use cases.  The file attachment adapters for NewspaperWorks use this
+    callback to allow programmatic assignment of pre-existing derivative
+    files before the primary file's file set has been created for a new
+    work.  The callback ensures that derivative files are attached,
+    stored using Hyrax file/path naming conventions, once the file set
+    has been created.  Because the Hyrax callback registry only allows single
     subscribers to any event, application developers who overwrite
     this handler, or integrate other gems that do likewise, must take care
     to create a custom composition that ensures all work and queued jobs

--- a/app/models/newspaper_works/derivative_attachment.rb
+++ b/app/models/newspaper_works/derivative_attachment.rb
@@ -1,4 +1,7 @@
 module NewspaperWorks
   class DerivativeAttachment < ApplicationRecord
+    validates :fileset_id, presence: true
+    validates :path, presence: true
+    validates :destination_name, presence: true
   end
 end

--- a/app/models/newspaper_works/derivative_attachment.rb
+++ b/app/models/newspaper_works/derivative_attachment.rb
@@ -1,0 +1,4 @@
+module NewspaperWorks
+  class DerivativeAttachment < ApplicationRecord
+  end
+end

--- a/app/models/newspaper_works/derivative_attachment.rb
+++ b/app/models/newspaper_works/derivative_attachment.rb
@@ -1,6 +1,7 @@
 module NewspaperWorks
   class DerivativeAttachment < ApplicationRecord
-    validates :fileset_id, presence: true
+    # We can store nil/optional fileset as interim value before fileset
+    #   construction, but we require at minimum, path, destination_name
     validates :path, presence: true
     validates :destination_name, presence: true
   end

--- a/app/models/newspaper_works/ingest_file_relation.rb
+++ b/app/models/newspaper_works/ingest_file_relation.rb
@@ -1,0 +1,14 @@
+module NewspaperWorks
+  class IngestFileRelation < ApplicationRecord
+    validates :file_path, presence: true
+    validates :derivative_path, presence: true
+
+    # Query by file path for all derivatives, as de-duplicated array of
+    #   derivative paths.
+    # @param path [String] Path to primary file
+    # @return [Array<String>] de-duplicated array of derivative paths.
+    def self.derivatives_for_file(path)
+      where(file_path: path).pluck(:derivative_path).uniq
+    end
+  end
+end

--- a/app/services/newspaper_works/pluggable_derivative_service.rb
+++ b/app/services/newspaper_works/pluggable_derivative_service.rb
@@ -72,9 +72,6 @@ class NewspaperWorks::PluggableDerivativeService
       # services = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
       # run all valid services, in order:
       services(name).each do |plugin|
-        # dest = nil
-        # dest = plugin.class.target_ext if plugin.class.respond_to?(:target_ext)
-        # next if skip_destination?(name, dest)
         plugin.send(name, *args)
       end
     else

--- a/app/services/newspaper_works/pluggable_derivative_service.rb
+++ b/app/services/newspaper_works/pluggable_derivative_service.rb
@@ -54,16 +54,27 @@ class NewspaperWorks::PluggableDerivativeService
     self.class.allowed_methods.include?(method_name) || super
   end
 
+  # get derivative services relevant to method name and file_set context
+  #   -- omits plugins if particular destination exists or will soon.
+  def services(method_name)
+    result = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
+    result.select do |plugin|
+      dest = nil
+      dest = plugin.class.target_ext if plugin.class.respond_to?(:target_ext)
+      !skip_destination?(method_name, dest)
+    end
+  end
+
   def method_missing(name, *args, **opts, &block)
     if respond_to_missing?(name)
       # we have an allowed method, construct services and include all valid
       #   services for the file_set
-      services = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
+      # services = plugins.map { |plugin| plugin.new(file_set) }.select(&:valid?)
       # run all valid services, in order:
-      services.each do |plugin|
-        dest = nil
-        dest = plugin.class.target_ext if plugin.class.respond_to?(:target_ext)
-        next if skip_destination?(name, dest)
+      services(name).each do |plugin|
+        # dest = nil
+        # dest = plugin.class.target_ext if plugin.class.respond_to?(:target_ext)
+        # next if skip_destination?(name, dest)
         plugin.send(name, *args)
       end
     else
@@ -77,7 +88,8 @@ class NewspaperWorks::PluggableDerivativeService
       return false if file_set.id.nil? || destination_name.nil?
       return false unless method_name == :create_derivatives
       # skip :create_derivatives if existing --> do not re-create
-      existing_derivative?(destination_name)
+      existing_derivative?(destination_name) ||
+        impending_derivative?(destination_name)
     end
 
     def existing_derivative?(name)
@@ -86,6 +98,17 @@ class NewspaperWorks::PluggableDerivativeService
         name
       )
       File.exist?(path)
+    end
+
+    # is there an impending attachment from ingest logged to db?
+    #   -- avoids stomping over pre-made derivative
+    #      for which an attachment is still in-progress.
+    def impending_derivative?(name)
+      result = NewspaperWorks::DerivativeAttachment.find_by(
+        fileset_id: file_set.id,
+        destination_name: name
+      )
+      !result.nil?
     end
 
     def derivative_path_factory

--- a/db/migrate/20181213213018_create_newspaper_works_derivative_attachments.rb
+++ b/db/migrate/20181213213018_create_newspaper_works_derivative_attachments.rb
@@ -1,0 +1,8 @@
+class CreateNewspaperWorksDerivativeAttachments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :newspaper_works_derivative_attachments do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181214181358_create_newspaper_works_derivative_attachments.rb
+++ b/db/migrate/20181214181358_create_newspaper_works_derivative_attachments.rb
@@ -1,8 +1,12 @@
 class CreateNewspaperWorksDerivativeAttachments < ActiveRecord::Migration[5.0]
   def change
     create_table :newspaper_works_derivative_attachments do |t|
+      t.string :fileset_id
+      t.string :path
+      t.string :destination_name
 
       t.timestamps
     end
+    add_index :newspaper_works_derivative_attachments, :fileset_id
   end
 end

--- a/db/migrate/20190107165909_create_newspaper_works_ingest_file_relations.rb
+++ b/db/migrate/20190107165909_create_newspaper_works_ingest_file_relations.rb
@@ -1,0 +1,11 @@
+class CreateNewspaperWorksIngestFileRelations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :newspaper_works_ingest_file_relations do |t|
+      t.string :file_path
+      t.string :derivative_path
+
+      t.timestamps
+    end
+    add_index :newspaper_works_ingest_file_relations, :file_path
+  end
+end

--- a/lib/generators/newspaper_works/install_generator.rb
+++ b/lib/generators/newspaper_works/install_generator.rb
@@ -9,6 +9,7 @@ module NewspaperWorks
       rake "newspaper_works:install:migrations"
     end
 
+    # rubocop:disable Metrics/MethodLength
     def register_worktypes
       inject_into_file 'config/initializers/hyrax.rb',
                        after: "Hyrax.config do |config|\n" do
@@ -18,9 +19,15 @@ module NewspaperWorks
           "  config.register_curation_concern :newspaper_issue\n" \
           "  config.register_curation_concern :newspaper_page\n" \
           "  config.register_curation_concern :newspaper_title\n" \
-          '  # == END GENERATED newspaper_works CONFIG == '
+          "\n" \
+          "  config.callback.set(:after_create_fileset) do |file_set, user|\n" \
+          "    require 'newspaper_works'\n" \
+          "    NewspaperWorks::Data.handle_after_create_fileset(file_set, user)\n" \
+          "  end\n" \
+          "  #== END GENERATED newspaper_works CONFIG ==\n\n"
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     def inject_routes
       inject_into_file 'config/routes.rb',

--- a/lib/generators/newspaper_works/install_generator.rb
+++ b/lib/generators/newspaper_works/install_generator.rb
@@ -3,7 +3,11 @@ require 'rails/generators'
 module NewspaperWorks
   # Install Generator Class
   class InstallGenerator < Rails::Generators::Base
-    source_root File.expand_path('../templates', __FILE__)
+    source_root File.expand_path('templates', __FILE__)
+
+    def copy_migrations
+      rake "newspaper_works:install:migrations"
+    end
 
     def register_worktypes
       inject_into_file 'config/initializers/hyrax.rb',

--- a/lib/newspaper_works/data.rb
+++ b/lib/newspaper_works/data.rb
@@ -8,5 +8,24 @@ module NewspaperWorks
   # Module for data access helper / adapter classes supporting, enhancing
   #   NewspaperWorks work models
   module Data
+    # Handler for after_create_fileset, to be called by block subscribing to
+    #   and overriding default Hyrax `:after_create_fileset` handler, via
+    #   app integrating newspaper_works.
+    def self.handle_after_create_fileset(file_set, user)
+      handle_queued_derivative_attachments(file_set)
+      # Hyrax queues this job by default, and since newspaper_works
+      #   overrides the single subscriber Hyrax uses to do so, we
+      #   must call this here:
+      FileSetAttachedEventJob.perform_later(file_set, user)
+    end
+
+    def self.handle_queued_derivative_attachments(file_set)
+      return if file_set.import_url.nil?
+      work = file_set.member_of.select(&:work?)[0]
+      derivatives = NewspaperWorks::Data::WorkDerivatives.of(work)
+      # For now, becuase this is IO-bound operation, it makes sense to have
+      #   this not be a job, but run inline:
+      derivatives.commit_queued!(file_set)
+    end
   end
 end

--- a/lib/newspaper_works/data/work_derivatives.rb
+++ b/lib/newspaper_works/data/work_derivatives.rb
@@ -20,6 +20,10 @@ module NewspaperWorks
       # @return [FileSet] fileset for work, with regard to these derivatives
       attr_accessor :fileset
 
+      # Parent pointer to WorkFile object representing fileset
+      # @return [NewspaperWorks::Data::WorkFile] WorkFile for fileset, work pair
+      attr_accessor :parent
+
       # Assigned attachment queue (of paths)
       # @return [Array<String>] list of paths queued for attachment
       attr_accessor :assigned
@@ -37,12 +41,12 @@ module NewspaperWorks
       end
 
       # alternate constructor spelling:
-      def self.of(work, fileset = nil)
-        new(work, fileset)
+      def self.of(work, fileset = nil, parent = nil)
+        new(work, fileset, parent)
       end
 
       # Adapt work and either specific or first fileset
-      def initialize(work, fileset = nil)
+      def initialize(work, fileset = nil, parent = nil)
         # adapted context usually work, may be string id of FileSet
         @work = work
         @fileset = fileset.nil? ? first_fileset : fileset
@@ -52,6 +56,8 @@ module NewspaperWorks
         @assigned = []
         # un-assignments for deletion
         @unassigned = []
+        # parent is NewspaperWorks::Data::WorkFile object for derivatives
+        @parent = parent
       end
 
       # Assignment state

--- a/lib/newspaper_works/data/work_derivatives.rb
+++ b/lib/newspaper_works/data/work_derivatives.rb
@@ -98,6 +98,7 @@ module NewspaperWorks
       # @param file [String, IO] path to file or IO object
       # @param name [String] destination name, usually file extension
       def attach(file, name)
+        log_attachment(file, name)
         mkdir_pairtree
         path = path_factory.derivative_path_for_reference(fileset, name)
         # if file argument is path, copy file
@@ -176,6 +177,14 @@ module NewspaperWorks
       end
 
       private
+
+        def log_attachment(path, name)
+          NewspaperWorks::DerivativeAttachment.create(
+            fileset_id: fileset_id,
+            path: path,
+            destination_name: name
+          )
+        end
 
         # Load all paths/names to @paths once, upon first access
         def load_paths

--- a/lib/newspaper_works/data/work_derivatives.rb
+++ b/lib/newspaper_works/data/work_derivatives.rb
@@ -122,6 +122,9 @@ module NewspaperWorks
           next unless File.exist?(path)
           attachment_record = DerivativeAttachment.where(path: path).first
           derivatives.attach(path, attachment_record.destination_name)
+          # update previously nil fileset id
+          attachment_record.fileset_id = file_set.id
+          attachment_record.save!
         end
         @fileset ||= file_set
         load_paths

--- a/lib/newspaper_works/data/work_derivatives.rb
+++ b/lib/newspaper_works/data/work_derivatives.rb
@@ -104,6 +104,7 @@ module NewspaperWorks
       # @param file [String, IO] path to file or IO object
       # @param name [String] destination name, usually file extension
       def attach(file, name)
+        raise RuntimeError('Cannot save for nil fileset') if fileset.nil?
         log_attachment(file, name)
         mkdir_pairtree
         path = path_factory.derivative_path_for_reference(fileset, name)
@@ -126,6 +127,7 @@ module NewspaperWorks
       # Delete a derivative file from work, by destination name
       # @param name [String] destination name, usually file extension
       def delete(name, force: nil)
+        raise RuntimeError('Cannot save for nil fileset') if fileset.nil?
         path = path_factory.derivative_path_for_reference(fileset, name)
         # will remove file, if it exists; won't remove pairtree, even
         #   if it becomes empty, as that is excess scope.

--- a/lib/newspaper_works/data/work_file.rb
+++ b/lib/newspaper_works/data/work_file.rb
@@ -22,7 +22,7 @@ module NewspaperWorks
         @work = work
         # If fileset is nil, presume *first* fileset of work, as in
         #   the single-file-per-work use-case:
-        @fileset = fileset.nil? ? first_fileset : fileset
+        @fileset = fileset
         # Parent is WorkFiles (container) object, if applciable:
         @parent = parent
       end
@@ -30,10 +30,12 @@ module NewspaperWorks
       # Get original repository object representing file (not fileset).
       # @return [ActiveFedora::File] repository file persistence object
       def unwrapped
+        return nil if @fileset.nil?
         @fileset.original_file
       end
 
       def ==(other)
+        return false if @fileset.nil?
         unwrapped.id == other.unwrapped.id
       end
 
@@ -41,6 +43,7 @@ module NewspaperWorks
       #   checkout file from repository/source as needed.
       # @return [String] path to working copy of binary
       def path
+        return nil if @fileset.nil?
         checkout
       end
 
@@ -48,6 +51,7 @@ module NewspaperWorks
       #   checkout file from repository/source as needed.
       # @return [String] byte data of binary/file payload
       def data
+        return '' if @fileset.nil?
         File.read(path, mode: 'rb')
       end
 
@@ -63,6 +67,7 @@ module NewspaperWorks
       # Get filename from stored metadata
       # @return [String] file name stored in repository metadata for file
       def name
+        return nil if @fileset.nil?
         unwrapped.original_name
       end
 
@@ -73,11 +78,6 @@ module NewspaperWorks
       end
 
       private
-
-        def first_fileset
-          filesets = @work.members.select { |m| m.class == FileSet }
-          filesets.empty? ? nil : filesets[0]
-        end
 
         def checkout
           file = @fileset.original_file

--- a/lib/newspaper_works/data/work_file.rb
+++ b/lib/newspaper_works/data/work_file.rb
@@ -69,7 +69,7 @@ module NewspaperWorks
       # Derivatives for fileset associated with this primary file object
       # @return [NewspaperWorks::Data::WorkDerviatives] derivatives adapter
       def derivatives
-        NewspaperWorks::Data::WorkDerivatives.of(work, fileset)
+        NewspaperWorks::Data::WorkDerivatives.of(work, fileset, self)
       end
 
       private

--- a/lib/newspaper_works/data/work_files.rb
+++ b/lib/newspaper_works/data/work_files.rb
@@ -15,16 +15,19 @@ module NewspaperWorks
         @work = work
         @assigned = []
         @unassigned = []
+        @derivatives = nil
       end
 
       # Derivatives for specified fileset or first fileset found.
       #   The `WorkDerivatives` adapter as assign/commmit! semantics just
       #   like `WorkFiles`, and also acts like a hash/mapping of
       #   destination names (usually file extension) to path of saved
-      #   derviative.
+      #   derviative.  Always returns same instance (memoized after first
+      #   use) of `WorkDerivatives`.
       # @return [NewspaperWorks::Data::WorkDerviatives] derivatives adapter
       def derivatives(fileset: nil)
-        NewspaperWorks::Data::WorkDerivatives.of(work, fileset)
+        return @derivatives unless @derivatives.nil?
+        @derivatives = NewspaperWorks::Data::WorkDerivatives.of(work, fileset)
       end
 
       # Assignment state

--- a/lib/newspaper_works/data/work_files.rb
+++ b/lib/newspaper_works/data/work_files.rb
@@ -26,8 +26,14 @@ module NewspaperWorks
       #   use) of `WorkDerivatives`.
       # @return [NewspaperWorks::Data::WorkDerviatives] derivatives adapter
       def derivatives(fileset: nil)
+        fileset ||= @fileset
         return @derivatives unless @derivatives.nil?
-        # Delegate actual construction to WorkFile.derivatives:
+        if fileset.nil?
+          # for the deferred assignement case, we have no fileset yet...
+          work_file = NewspaperWorks::Data::WorkFile.of(work, nil, self)
+          return work_file.derivatives
+        end
+        # Otherwise, delegate actual construction to WorkFile.derivatives:
         @derivatives = values[0].derivatives
       end
 

--- a/lib/newspaper_works/data/work_files.rb
+++ b/lib/newspaper_works/data/work_files.rb
@@ -27,7 +27,8 @@ module NewspaperWorks
       # @return [NewspaperWorks::Data::WorkDerviatives] derivatives adapter
       def derivatives(fileset: nil)
         return @derivatives unless @derivatives.nil?
-        @derivatives = NewspaperWorks::Data::WorkDerivatives.of(work, fileset)
+        # Delegate actual construction to WorkFile.derivatives:
+        @derivatives = values[0].derivatives
       end
 
       # Assignment state

--- a/spec/lib/newspaper_works/data/work_derivatives_spec.rb
+++ b/spec/lib/newspaper_works/data/work_derivatives_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe NewspaperWorks::Data::WorkDerivatives do
   let(:txt1) do
     file = Tempfile.new(['txt1', '.txt'])
     file.write('hello')
+    file.flush
     file.path
   end
 

--- a/spec/lib/newspaper_works/data/work_derivatives_spec.rb
+++ b/spec/lib/newspaper_works/data/work_derivatives_spec.rb
@@ -178,5 +178,15 @@ RSpec.describe NewspaperWorks::Data::WorkDerivatives do
       expect(adapter.path('txt')).to be nil
       expect(adapter.keys).not_to include 'txt'
     end
+
+    it "persists log of attachment to RDBMS" do
+      adapter.attach(txt1, 'superthing')
+      result = NewspaperWorks::DerivativeAttachment.find_by(
+        fileset_id: adapter.fileset.id,
+        path: txt1,
+        destination_name: 'superthing'
+      )
+      expect(result).not_to be_nil
+    end
   end
 end

--- a/spec/lib/newspaper_works/data/work_derivatives_spec.rb
+++ b/spec/lib/newspaper_works/data/work_derivatives_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe NewspaperWorks::Data::WorkDerivatives do
   let(:adapter) { described_class.new(work) }
 
   let(:txt1) do
-    file = Tempfile.new('txt1.txt')
+    file = Tempfile.new(['txt1', '.txt'])
     file.write('hello')
     file.close
     file.path
@@ -180,11 +180,11 @@ RSpec.describe NewspaperWorks::Data::WorkDerivatives do
     end
 
     it "persists log of attachment to RDBMS" do
-      adapter.attach(txt1, 'superthing')
+      adapter.assign(txt1)
       result = NewspaperWorks::DerivativeAttachment.find_by(
         fileset_id: adapter.fileset.id,
         path: txt1,
-        destination_name: 'superthing'
+        destination_name: 'txt'
       )
       expect(result).not_to be_nil
     end

--- a/spec/lib/newspaper_works/data/work_derivatives_spec.rb
+++ b/spec/lib/newspaper_works/data/work_derivatives_spec.rb
@@ -188,5 +188,19 @@ RSpec.describe NewspaperWorks::Data::WorkDerivatives do
       )
       expect(result).not_to be_nil
     end
+
+    it "persists a log of path relation to primary file" do
+      # this is an integration test by practical necessity, with
+      #   WorkFiles adapting a bare work with no fileset.
+      work_files = NewspaperWorks::Data::WorkFiles.of(bare_work)
+      work_files.assign(example_gray_jp2)
+      adapter = work_files.derivatives
+      adapter.assign(txt1)
+      result = NewspaperWorks::IngestFileRelation.find_by(
+        derivative_path: txt1,
+        file_path: example_gray_jp2
+      )
+      expect(result).not_to be_nil
+    end
   end
 end

--- a/spec/lib/newspaper_works/data/work_file_spec.rb
+++ b/spec/lib/newspaper_works/data/work_file_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe NewspaperWorks::Data::WorkFile do
   let(:work) { work_with_file }
 
   describe "adapter composition" do
-    it "adapts work with implied fileset" do
+    it "adapts work with nil fileset" do
       adapter = described_class.new(work)
       expect(adapter.work).to be work
-      fileset = work.members.select { |m| m.class == FileSet }[0]
-      expect(adapter.fileset).to be fileset
+      expect(adapter.fileset).to be_nil
     end
 
     it "adapts work with 'of' alt constructor" do

--- a/spec/lib/newspaper_works/data/work_file_spec.rb
+++ b/spec/lib/newspaper_works/data/work_file_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe NewspaperWorks::Data::WorkFile do
         NewspaperWorks::Data::WorkDerivatives
       expect(adapter.derivatives.fileset).to be fileset
       expect(adapter.derivatives.work).to be work
+      expect(adapter.derivatives.parent).to be adapter
     end
   end
 end

--- a/spec/lib/newspaper_works/data/work_files_spec.rb
+++ b/spec/lib/newspaper_works/data/work_files_spec.rb
@@ -183,6 +183,9 @@ RSpec.describe NewspaperWorks::Data::WorkFiles do
     it "gets derivatives for first fileset" do
       fileset = work.members.select { |m| m.class == FileSet }[0]
       adapter = described_class.of(work)
+      # is the same instance across access:
+      expect(adapter.derivatives).to be adapter.derivatives
+      # adapts same context(s):
       expect(adapter.derivatives.fileset).to be fileset
       expect(adapter.derivatives.work).to be work
       expect(adapter.derivatives.class).to eq \

--- a/spec/lib/newspaper_works/data/work_files_spec.rb
+++ b/spec/lib/newspaper_works/data/work_files_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe NewspaperWorks::Data::WorkFiles do
       # is the same instance across access:
       expect(adapter.derivatives).to be adapter.derivatives
       # adapts same context(s):
-      expect(adapter.derivatives.fileset).to be fileset
+      expect(adapter.derivatives.fileset.id).to eq fileset.id
       expect(adapter.derivatives.work).to be work
       expect(adapter.derivatives.class).to eq \
         NewspaperWorks::Data::WorkDerivatives

--- a/spec/lib/newspaper_works/data/work_files_spec.rb
+++ b/spec/lib/newspaper_works/data/work_files_spec.rb
@@ -183,8 +183,6 @@ RSpec.describe NewspaperWorks::Data::WorkFiles do
     it "gets derivatives for first fileset" do
       fileset = work.members.select { |m| m.class == FileSet }[0]
       adapter = described_class.of(work)
-      # is the same instance across access:
-      expect(adapter.derivatives).to be adapter.derivatives
       # adapts same context(s):
       expect(adapter.derivatives.fileset.id).to eq fileset.id
       expect(adapter.derivatives.work).to be work

--- a/spec/lib/newspaper_works/data/work_files_spec.rb
+++ b/spec/lib/newspaper_works/data/work_files_spec.rb
@@ -190,6 +190,9 @@ RSpec.describe NewspaperWorks::Data::WorkFiles do
       expect(adapter.derivatives.work).to be work
       expect(adapter.derivatives.class).to eq \
         NewspaperWorks::Data::WorkDerivatives
+      # transitive parent/child relationship, can traverse to adapter from
+      # derivatives:
+      expect(adapter.derivatives.parent.parent).to be adapter
     end
   end
 end

--- a/spec/models/newspaper_works/derivative_attachment_spec.rb
+++ b/spec/models/newspaper_works/derivative_attachment_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+module NewspaperWorks
+  RSpec.describe DerivativeAttachment, type: :model do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/spec/models/newspaper_works/derivative_attachment_spec.rb
+++ b/spec/models/newspaper_works/derivative_attachment_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module NewspaperWorks
   RSpec.describe DerivativeAttachment, type: :model do
-    it "requires all columns to be considered complete" do
+    it "requires some columns to be considered complete" do
       model = described_class.create
       # attempt save without required data; expect failure
       expect { model.save! }.to raise_exception(ActiveRecord::RecordInvalid)
@@ -21,6 +21,14 @@ module NewspaperWorks
     it "saves when all fields completely set" do
       model = described_class.create
       model.fileset_id = 'someid123'
+      model.path = '/path/to/somefile'
+      model.destination_name = 'txt'
+      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+    end
+
+    it "saves when only path, destination_name set" do
+      model = described_class.create
+      model.fileset_id = nil
       model.path = '/path/to/somefile'
       model.destination_name = 'txt'
       expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)

--- a/spec/models/newspaper_works/derivative_attachment_spec.rb
+++ b/spec/models/newspaper_works/derivative_attachment_spec.rb
@@ -1,7 +1,29 @@
-require 'rails_helper'
+require 'spec_helper'
 
 module NewspaperWorks
   RSpec.describe DerivativeAttachment, type: :model do
-    pending "add some examples to (or delete) #{__FILE__}"
+    it "requires all columns to be considered complete" do
+      model = described_class.create
+      # attempt save without required data; expect failure
+      expect { model.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+    end
+
+    it "saves when constructed with all field values" do
+      model = described_class.create(
+        fileset_id: 'a1b2c3d4e5',
+        path: '/path/to/somefile',
+        destination_name: 'txt'
+      )
+      # attempt save without required data; expect failure
+      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+    end
+
+    it "saves when all fields completely set" do
+      model = described_class.create
+      model.fileset_id = 'someid123'
+      model.path = '/path/to/somefile'
+      model.destination_name = 'txt'
+      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+    end
   end
 end

--- a/spec/models/newspaper_works/ingest_file_relation_spec.rb
+++ b/spec/models/newspaper_works/ingest_file_relation_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+module NewspaperWorks
+  RSpec.describe IngestFileRelation, type: :model do
+    def make_test_records
+      # two unique values
+      described_class.create(
+        file_path: '/some/path/to/this',
+        derivative_path: '/some/path/to/that'
+      )
+      described_class.create(
+        file_path: '/some/path/to/this',
+        derivative_path: '/some/path/to/other_thing'
+      )
+      # a duplicate will save, presumption is that dupes are filtered on query:
+      described_class.create(
+        file_path: '/some/path/to/this',
+        derivative_path: '/some/path/to/other_thing'
+      )
+    end
+
+    it "will not save unless record is complete" do
+      model = described_class.create
+      # attempt save without required data; expect failure
+      expect { model.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+      model2 = described_class.create
+      model2.file_path = '/path/to/sourcefile.tiff'
+      expect { model2.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+      model3 = described_class.create
+      model3.derivative_path = '/path/to/sourcefile.tiff'
+      expect { model3.save! }.to raise_exception(ActiveRecord::RecordInvalid)
+    end
+
+    it "will save sufficiently constructed record" do
+      model = described_class.create(
+        file_path: '/path/to/this',
+        derivative_path: '/path/to/that'
+      )
+      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+    end
+
+    it "will save when all fields completely set" do
+      model = described_class.create
+      model.file_path = '/path/to/sourcefile.tiff'
+      model.derivative_path = '/path/to/derived.jp2'
+      expect { model.save! }.not_to raise_exception(ActiveRecord::RecordInvalid)
+    end
+
+    it "can query derivative paths for primary file" do
+      make_test_records
+      result = described_class.derivatives_for_file('/some/path/to/this')
+      expect(result).to be_an Array
+      expect(result.size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
Implements mechanisms to persist file attachment/assignment information such that:

1. PluggableDerivativeService can respect already existing derivative assignments by not re-creating, or having a race condition from attempting.
2. An `:after_create_fileset` callback can address assignment to WorkDerivatives when the work's fileset has not yet been created.

This fixes the two primary shortfalls of previous implementation addressing #57, and should, upon merge, close #70 and #82.

Note: there is a minor change to the README describing a gotcha on the Hyrax callback registry for potential integrators of newspaper_works.