### PR TITLE
Upgrade to Ubuntu 16.04 LTS (Xenial) on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,7 @@ cache:
   bundler: true
 
 before_install:
-  # OpenJPEG 2000 2.x backport PPA
-  # openjp2 is fully supported in Ubuntu 16.04 LTS
-  # - sudo add-apt-repository ppa:aacid/openjp2trusty -y
   - sudo apt-get update -q
-  # - sudo apt-get install libopenjp2-tools -y
   - gem update --system
   - gem install bundler
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
@@ -35,7 +31,7 @@ before_install:
   - sudo chmod +x /opt/install/fits-1.3.0/*.sh
   - sudo ln -s /opt/install/fits-1.3.0/fits.sh /usr/local/bin/fits.sh
   - sudo wget -q -O /etc/ImageMagick-6/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
-  - sudo wget -q -O /opt/install/fits-1.3.0/xml/fits.xml https://gist.github.com/1fa030b4eb6c5904b9bda9bbd3ff91a7.git
+  - sudo wget -q -O /opt/install/fits-1.3.0/xml/fits.xml d84eca9a9a170f8f/raw/ebb1a285726e4f5c2309b4f6eceed29fa1369538/fits.xml
 rvm:
   - 2.5.3
 
@@ -53,4 +49,3 @@ env:
 
 services:
   - redis
-#before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - sudo chmod +x /opt/install/fits-1.3.0/*.sh
   - sudo ln -s /opt/install/fits-1.3.0/fits.sh /usr/local/bin/fits.sh
   - sudo wget -q -O /etc/ImageMagick-6/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
-  - sudo wget -q -O /opt/install/fits-1.3.0/xml/fits.xml d84eca9a9a170f8f/raw/ebb1a285726e4f5c2309b4f6eceed29fa1369538/fits.xml
+  - sudo wget -q -O /opt/install/fits-1.3.0/xml/fits.xml https://gist.githubusercontent.com/brianmcbride/af3fb21fb50a1331d84eca9a9a170f8f/raw/ebb1a285726e4f5c2309b4f6eceed29fa1369538/fits.xml
 rvm:
   - 2.5.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - libreoffice
     - poppler-utils
     - tesseract-ocr
+    - libopenjp2-7
 cache:
   bundler: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - sudo unzip /opt/install/fits-1.3.0.zip -d /opt/install/fits-1.3.0
   - sudo chmod +x /opt/install/fits-1.3.0/*.sh
   - sudo ln -s /opt/install/fits-1.3.0/fits.sh /usr/local/bin/fits.sh
-  - sudo wget -q -O /etc/ImageMagick/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
+  #- sudo wget -q -O /etc/ImageMagick/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
 
 rvm:
   - 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - sudo chmod +x /opt/install/fits-1.3.0/*.sh
   - sudo ln -s /opt/install/fits-1.3.0/fits.sh /usr/local/bin/fits.sh
   - sudo wget -q -O /etc/ImageMagick-6/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
-
+  - sudo wget -q -O /opt/install/fits-1.3.0/xml/fits.xml https://gist.github.com/1fa030b4eb6c5904b9bda9bbd3ff91a7.git
 rvm:
   - 2.5.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable
   apt:
     sources:
-      - "trusty-media"
+      - "xenial-media"
     packages:
     - ghostscript
     - graphicsmagick
@@ -18,9 +18,10 @@ cache:
 
 before_install:
   # OpenJPEG 2000 2.x backport PPA
-  - sudo add-apt-repository ppa:aacid/openjp2trusty -y
+  # openjp2 is fully supported in Ubuntu 16.04 LTS
+  # - sudo add-apt-repository ppa:aacid/openjp2trusty -y
   - sudo apt-get update -q
-  - sudo apt-get install libopenjp2-tools -y
+  # - sudo apt-get install libopenjp2-tools -y
   - gem update --system
   - gem install bundler
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
@@ -31,7 +32,7 @@ before_install:
   - sudo wget -q -O /etc/ImageMagick/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
 
 rvm:
-  - 2.5.0
+  - 2.5.3
 
 env:
   global:
@@ -42,8 +43,8 @@ env:
   # It should be sufficient to test only the latest of the patch versions for a minor version, they
   # should be compatible across patch versions (only bug fixes are released in patch versions).
   matrix:
-    - "RAILS_VERSION=5.0.6"
-    - "RAILS_VERSION=5.1.4"
+    - "RAILS_VERSION=5.1.6"
+    - "RAILS_VERSION=5.0.7"
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 dist: xenial
 
+jdk:
+  - oraclejdk8
+  - openjdk8
+
 addons:
   chrome: stable
   apt:
@@ -49,7 +53,3 @@ env:
 services:
   - redis
 #before_script:
-#  - jdk_switcher use oraclejdk8
-
-jdk:
-  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 dist: xenial
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 addons:
@@ -34,7 +33,7 @@ before_install:
   - sudo unzip /opt/install/fits-1.3.0.zip -d /opt/install/fits-1.3.0
   - sudo chmod +x /opt/install/fits-1.3.0/*.sh
   - sudo ln -s /opt/install/fits-1.3.0/fits.sh /usr/local/bin/fits.sh
-  #- sudo wget -q -O /etc/ImageMagick/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
+  - sudo wget -q -O /etc/ImageMagick/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
 
 rvm:
   - 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - poppler-utils
     - tesseract-ocr
     - libopenjp2-7
+    - libopenjp2-tools
 cache:
   bundler: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - sudo unzip /opt/install/fits-1.3.0.zip -d /opt/install/fits-1.3.0
   - sudo chmod +x /opt/install/fits-1.3.0/*.sh
   - sudo ln -s /opt/install/fits-1.3.0/fits.sh /usr/local/bin/fits.sh
-  - sudo wget -q -O /etc/ImageMagick/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
+  - sudo wget -q -O /etc/ImageMagick-6/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
 
 rvm:
   - 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ env:
     - "RAILS_VERSION=5.0.7"
 
 services:
-  - redis-server
-before_script:
-- jdk_switcher use oraclejdk8
+  - redis
+#before_script:
+#  - jdk_switcher use oraclejdk8
+
+jdk:
+  - oraclejdk8


### PR DESCRIPTION
Upgrade to Ubuntun 16.04 LTS (Xenial) on Travis
Additional updates include:

Added the following:
- openjdk8
- libopenjp2
- ibopenjp2-tools
- redis
- custom configuration for fits (disabled tika)

Updated the following:

- RVM from 2.5.0 to 2.5.3
- Rails version from 5.0.6-5.1.4 to 5.0.7-5.1.6
- Location of policy.xml file for ImageMagick

Removed the following:
- redis-server
- libopenjp2 ppa
- jdkswitcher
- oraclejdk8

