### PR TITLE
NDNP Issue/Page ingest traversal

### DIFF
--- a/lib/newspaper_works/ingest.rb
+++ b/lib/newspaper_works/ingest.rb
@@ -1,6 +1,7 @@
 require 'newspaper_works/ingest/pdf_images'
 require 'newspaper_works/ingest/pdf_pages'
 require 'newspaper_works/ingest/base_ingest'
+require 'newspaper_works/ingest/ndnp'
 require 'newspaper_works/ingest/newspaper_page_ingest'
 require 'newspaper_works/ingest/newspaper_issue_ingest'
 

--- a/lib/newspaper_works/ingest/ndnp.rb
+++ b/lib/newspaper_works/ingest/ndnp.rb
@@ -1,0 +1,13 @@
+require 'newspaper_works/ingest/ndnp/ndnp_mets_helper'
+require 'newspaper_works/ingest/ndnp/page_ingest'
+require 'newspaper_works/ingest/ndnp/page_metadata'
+require 'newspaper_works/ingest/ndnp/issue_ingest'
+require 'newspaper_works/ingest/ndnp/issue_metadata'
+
+module NewspaperWorks
+  module Ingest
+    # Module for NDNP-specific ingest components
+    module NDNP
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
@@ -29,7 +29,7 @@ module NewspaperWorks
         end
 
         def page_by_dmdid(dmdid)
-          NewspaperWorks::Ingest::NDNP::PageIngest.new(@path, dmdid)
+          NewspaperWorks::Ingest::NDNP::PageIngest.new(@path, dmdid, self)
         end
 
         def page_by_sequence_number(n)

--- a/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
@@ -1,0 +1,54 @@
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class IssueIngest
+        include Enumerable
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
+        attr_accessor :path, :doc
+
+        def initialize(path)
+          @path = path
+          @doc = nil
+          @metadata = nil
+          load_doc
+        end
+
+        def inspect
+          format(
+            "<#{self.class}:0x000000000%<oid>x\n" \
+              "\tpath: '#{path}',\n",
+            oid: object_id << 1
+          )
+        end
+
+        def identifier
+          metadata.lccn
+        end
+
+        def page_by_dmdid(dmdid)
+        end
+
+        def page_by_sequence_number(n)
+        end
+
+        def each(&block)
+        end
+
+        def size
+        end
+
+        def metadata
+          return @metadata unless @metadata.nil?
+          @metadata = NewspaperWorks::Ingest::NDNP::IssueMetadata.new(path)
+        end
+
+        private
+
+          def load_doc
+            @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
+          end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
@@ -54,7 +54,10 @@ module NewspaperWorks
 
         def metadata
           return @metadata unless @metadata.nil?
-          @metadata = NewspaperWorks::Ingest::NDNP::IssueMetadata.new(path)
+          @metadata = NewspaperWorks::Ingest::NDNP::IssueMetadata.new(
+            path,
+            self
+          )
         end
 
         private

--- a/lib/newspaper_works/ingest/ndnp/issue_metadata.rb
+++ b/lib/newspaper_works/ingest/ndnp/issue_metadata.rb
@@ -1,0 +1,80 @@
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class IssueMetadata
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
+        attr_accessor :path, :doc
+
+        def initialize(path)
+          @path = path
+          @doc = nil
+          load_doc
+        end
+
+        def inspect
+          format(
+            "<#{self.class}:0x000000000%<oid>x\n" \
+              "\tpath: '#{path}',\n",
+            oid: object_id << 1
+          )
+        end
+
+        # LCCN (mandatory)
+        # @return [String]
+        def lccn
+          xpath("//mods:identifier[@type='lccn']").text
+        end
+
+        # Volume number (optional)
+        # @return [String,NilClass]
+        def volume
+          result = xpath("//mods:detail[@type='volume']/mods:number")
+          return if result.size.zero?
+          result.text
+        end
+
+        # Issue number (optional)
+        # @return [String,NilClass]
+        def issue
+          result = xpath("//mods:detail[@type='issue']/mods:number")
+          return if result.size.zero?
+          result.text
+        end
+
+        # Edition name, with fallback to edition number
+        #   Edition name is optional ("caption" / "label"), but is
+        #     the preferred notion of "edition" field in newspaper_works,
+        #     and for the bibo:edition predicate.
+        #   Edition number (aka "Edition Order" in NDNP specs) is mandatory
+        #     but also arbitrary. We only use this as a fallback value,
+        #     represented in String form, only when edition name is unavailable.
+        # @return [String]
+        def edition
+          ed_name = xpath("//mods:detail[@type='edition']/mods:caption")
+          return ed_name.text unless ed_name.size.zero?
+          # fallback to edition number if name unavailable:
+          xpath("//mods:detail[@type='edition']/mods:number").text
+        end
+
+        # Issue date (mandatory field) as ISO 8601 datestamp string
+        # @return [String] (ISO-8601 date) publication date
+        def publication_date
+          xpath("//mods:originInfo/mods:dateIssued").text
+        end
+
+        # Original Source Repository (NDNP-mandatory)
+        # @return [String]
+        def held_by
+          xpath("//mods:physicalLocation").first['displayLabel']
+        end
+
+        private
+
+          def load_doc
+            @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
+          end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/issue_metadata.rb
+++ b/lib/newspaper_works/ingest/ndnp/issue_metadata.rb
@@ -6,8 +6,9 @@ module NewspaperWorks
 
         attr_accessor :path, :doc
 
-        def initialize(path)
+        def initialize(path, parent = nil)
           @path = path
+          @parent = parent
           @doc = nil
           load_doc
         end
@@ -72,6 +73,7 @@ module NewspaperWorks
         private
 
           def load_doc
+            @doc = @parent.doc unless @parent.nil?
             @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
           end
       end

--- a/lib/newspaper_works/ingest/ndnp/ndnp_mets_helper.rb
+++ b/lib/newspaper_works/ingest/ndnp/ndnp_mets_helper.rb
@@ -1,0 +1,52 @@
+require 'nokogiri'
+
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      # Mixin for mets-specific XPath and traversal of issue/page data
+      module NDNPMetsHelper
+        # DRY XPath without repeatedly specifying default namespace urlmap
+        def xpath(expr, context = nil)
+          context ||= doc
+          context.xpath(
+            expr,
+            mets: 'http://www.loc.gov/METS/',
+            mods: 'http://www.loc.gov/mods/v3'
+          )
+        end
+
+        def dmd_node
+          xpath("//mets:dmdSec[@ID='#{dmdid}']")
+        end
+
+        def normalize_path(specified_path)
+          return specified_path if specified_path.start_with?('/')
+          basename = File.dirname(path)
+          File.join(basename, specified_path)
+        end
+
+        # returns hash of "use" key string to path value
+        # rubocop:disable Metrics/MethodLength (xpath is wordy!)
+        def page_files
+          # get pointers from structmap:
+          file_group = xpath("//mets:structMap//mets:div[@DMDID='#{dmdid}']")
+          result = xpath('mets:fptr', file_group).map do |fptr|
+            file_id = fptr['FILEID']
+            file_node = xpath(
+              "//mets:fileSec//mets:fileGrp//mets:file[@ID='#{file_id}']"
+            ).first
+            [
+              file_node['USE'],
+              xpath('mets:FLocat', file_node).first.attribute_with_ns(
+                'href',
+                'http://www.w3.org/1999/xlink'
+              ).to_s
+            ]
+          end
+          result.to_h
+        end
+        # rubocop:enable Metrics/MethodLength
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/ndnp_mets_helper.rb
+++ b/lib/newspaper_works/ingest/ndnp/ndnp_mets_helper.rb
@@ -5,13 +5,18 @@ module NewspaperWorks
     module NDNP
       # Mixin for mets-specific XPath and traversal of issue/page data
       module NDNPMetsHelper
+        XML_NS = {
+          mets: 'http://www.loc.gov/METS/',
+          mods: 'http://www.loc.gov/mods/v3',
+          MODS: 'http://www.loc.gov/mods/v3'
+        }.freeze
+
         # DRY XPath without repeatedly specifying default namespace urlmap
         def xpath(expr, context = nil)
           context ||= doc
           context.xpath(
             expr,
-            mets: 'http://www.loc.gov/METS/',
-            mods: 'http://www.loc.gov/mods/v3'
+            **XML_NS
           )
         end
 

--- a/lib/newspaper_works/ingest/ndnp/page_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/page_ingest.rb
@@ -6,11 +6,12 @@ module NewspaperWorks
 
         attr_accessor :path, :dmdid, :doc
 
-        def initialize(path = nil, dmdid = nil)
+        def initialize(path = nil, dmdid = nil, parent = nil)
           raise ArgumentError('No path provided') if path.nil?
           @path = path
           @dmdid = dmdid
           @doc = nil
+          @parent = parent
           @metadata = nil
           load_doc
         end
@@ -40,6 +41,7 @@ module NewspaperWorks
         private
 
           def load_doc
+            @doc = @parent.doc unless @parent.nil?
             @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
           end
       end

--- a/lib/newspaper_works/ingest/ndnp/page_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/page_ingest.rb
@@ -1,0 +1,48 @@
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class PageIngest
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
+        attr_accessor :path, :dmdid, :doc
+
+        def initialize(path = nil, dmdid = nil)
+          raise ArgumentError('No path provided') if path.nil?
+          @path = path
+          @dmdid = dmdid
+          @doc = nil
+          @metadata = nil
+          load_doc
+        end
+
+        def inspect
+          format(
+            "<#{self.class}:0x000000000%<oid>x\n" \
+              "\tpath: '#{path}',\n" \
+              "\tdmdid: '#{dmdid}' ...>",
+            oid: object_id << 1
+          )
+        end
+
+        def files
+          page_files.values.map(&method(:normalize_path))
+        end
+
+        def metadata
+          return @metadata unless @metadata.nil?
+          @metadata = NewspaperWorks::Ingest::NDNP::PageMetadata.new(
+            path,
+            self,
+            dmdid
+          )
+        end
+
+        private
+
+          def load_doc
+            @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
+          end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/page_metadata.rb
+++ b/lib/newspaper_works/ingest/ndnp/page_metadata.rb
@@ -4,6 +4,7 @@ module NewspaperWorks
   module Ingest
     module NDNP
       class PageMetadata
+        # mixin convenience methods for NDNP XML, plus XML_NS hash
         include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
 
         attr_accessor :path, :dmdid, :doc
@@ -29,24 +30,31 @@ module NewspaperWorks
         # Printed page number, if printed; optional field in NDNP spec.
         #   "Number" is used liberaly, and may contain both alpha
         #   and numeric characters.  As such, return value is String.
+        #
+        #   Recommendation: callers may (strongly recommended) fall back to:
+        #   `page.page_number || page.page_sequence_number.to_s`,
+        #   however, this is not implemented automatically by this class.
+        #
         # @return [String, NilClass] Page "number" string
         def page_number
           detail = dmd_node.xpath(
-            ".//mods:mods//mods:detail[@type='page number']"
+            ".//mods:mods//mods:detail[@type='page number']",
+            **XML_NS
           )
           return nil if detail.size.zero?
-          detail.xpath("mods:number").first.text
+          detail.xpath("mods:number", **XML_NS).first.text
         end
 
-        # Mandatory page sequcnce number, indexical to order in issue.
+        # Mandatory page sequence number, indexical to order in issue.
         #   "Number" here is one-indexed positive integer, position in
         #   issue.
         # @return [Integer] Page sequence number, positive integer
         def page_sequence_number
           detail = dmd_node.xpath(
-            ".//mods:mods//mods:extent[@unit='pages']"
+            ".//mods:mods//mods:extent[@unit='pages']",
+            **XML_NS
           )
-          detail.xpath("mods:start").first.text.to_i
+          detail.xpath("mods:start", **XML_NS).first.text.to_i
         end
 
         # Extract identifier from page ALTO, based on file name.

--- a/lib/newspaper_works/ingest/ndnp/page_metadata.rb
+++ b/lib/newspaper_works/ingest/ndnp/page_metadata.rb
@@ -1,0 +1,95 @@
+require 'nokogiri'
+
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class PageMetadata
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
+        attr_accessor :path, :dmdid, :doc
+
+        def initialize(path = nil, parent = nil, dmdid = nil)
+          raise ArgumentError('No context provided') if path.nil? && parent.nil?
+          @path = path
+          @parent = parent
+          @dmdid = dmdid
+          @doc = nil
+          load_doc
+        end
+
+        def inspect
+          format(
+            "<#{self.class}:0x000000000%<oid>x\n" \
+              "\tpath: '#{path}',\n" \
+              "\tdmdid: '#{dmdid}' ...>",
+            oid: object_id << 1
+          )
+        end
+
+        # Printed page number, if printed; optional field in NDNP spec.
+        #   "Number" is used liberaly, and may contain both alpha
+        #   and numeric characters.  As such, return value is String.
+        # @return [String, NilClass] Page "number" string
+        def page_number
+          detail = dmd_node.xpath(
+            ".//mods:mods//mods:detail[@type='page number']"
+          )
+          return nil if detail.size.zero?
+          detail.xpath("mods:number").first.text
+        end
+
+        # Mandatory page sequcnce number, indexical to order in issue.
+        #   "Number" here is one-indexed positive integer, position in
+        #   issue.
+        # @return [Integer] Page sequence number, positive integer
+        def page_sequence_number
+          detail = dmd_node.xpath(
+            ".//mods:mods//mods:extent[@unit='pages']"
+          )
+          detail.xpath("mods:start").first.text.to_i
+        end
+
+        # Extract identifier from page ALTO, based on file name.
+        #   XML parsing of big documents are expensive, so use regex to
+        #   scan for fileName element, and return its value.
+        # @return [String,NilClass] file name or path, or nil.
+        def identifier
+          matches = page_alto.scan(/<fileName>([^<]*)<\/fileName>/).first
+          matches.size.zero? ? nil : matches[0]
+        end
+
+        def height
+          alto_page_meta('HEIGHT').to_i
+        end
+
+        def width
+          alto_page_meta('WIDTH').to_i
+        end
+
+        private
+
+          def load_doc
+            @doc = @parent.doc unless @parent.nil?
+            @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
+          end
+
+          def alto_path
+            specified_path = page_files['ocr']
+            normalize_path(specified_path)
+          end
+
+          def page_alto
+            File.read(alto_path)
+          end
+
+          def alto_page_meta(key)
+            matches = page_alto.scan(/(<Page [^>]*>)/).first
+            return if matches.size.zero?
+            # parse xml <Page> start tag fragment, get attributes:
+            page_tag = Nokogiri::XML(matches[0]).root
+            page_tag[key]
+          end
+      end
+    end
+  end
+end

--- a/newspaper_works.gemspec
+++ b/newspaper_works.gemspec
@@ -30,7 +30,7 @@ SUMMARY
 
   spec.add_development_dependency 'bixby'
   spec.add_development_dependency 'capybara', '~> 2.4', '< 2.18.0'
-  spec.add_development_dependency 'engine_cart', '~> 2.0'
+  spec.add_development_dependency 'engine_cart', '~> 2.2'
   spec.add_development_dependency "factory_bot", '~> 4.4'
   spec.add_development_dependency "faraday"
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.5', '>= 0.5.1'

--- a/spec/lib/newspaper_works/ingest/ndnp/issue_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/issue_ingest_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::IssueIngest do
+  include_context "ndnp fixture setup"
+
+  describe "sample fixture 'batch_local'" do
+    let(:issue) { described_class.new(issue1) }
+
+    it "gets metadata" do
+      expect(issue.metadata).to be_a NewspaperWorks::Ingest::NDNP::IssueMetadata
+      # uses same Nokogiri document context:
+      expect(issue.metadata.doc).to be issue.doc
+      # has identifier method equivalent to lccn
+      expect(issue.identifier).to eq issue.metadata.lccn
+    end
+
+    it "gets page by dmdid" do
+      page = issue.page_by_dmdid('pageModsBib8')
+      expect(page).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+      expect(page.metadata.page_sequence_number).to eq 1
+      expect(page.dmdid).to eq 'pageModsBib8'
+    end
+
+    it "gets page by sequence number" do
+      page = issue.page_by_sequence_number(1)
+      expect(page.metadata.page_sequence_number).to eq 1
+      expect(page.dmdid).to eq 'pageModsBib8'
+      page = issue.page_by_sequence_number(2)
+      expect(page.metadata.page_sequence_number).to eq 2
+      expect(page.dmdid).to eq 'pageModsBib6'
+    end
+
+    it "shares xml document context with contained pages" do
+      page = issue.page_by_sequence_number(1)
+      expect(page.doc).to be issue.doc
+    end
+
+    it "enumerates expected pages" do
+      # enumerate by casting issue to Array
+      pages = issue.to_a
+      expect(pages.size).to eq 2
+      expect(pages[0]).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+      expect(pages[0].metadata.page_sequence_number).to eq 1
+    end
+
+    it "gets size, in page count" do
+      pages = issue.to_a
+      expect(issue.size).to eq pages.size
+      expect(issue.size).to eq issue.dmdids.size
+    end
+  end
+
+  describe "sample fixture 'batch_test_ver01'" do
+    let(:issue) { described_class.new(issue2) }
+
+    it "gets metadata" do
+      expect(issue.metadata).to be_a NewspaperWorks::Ingest::NDNP::IssueMetadata
+      # uses same Nokogiri document context:
+      expect(issue.metadata.doc).to be issue.doc
+      # has identifier method equivalent to lccn
+      expect(issue.identifier).to eq issue.metadata.lccn
+    end
+
+    it "gets page by dmdid" do
+      page = issue.page_by_dmdid('pageModsBib1')
+      expect(page).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+      expect(page.metadata.page_sequence_number).to eq 1
+      expect(page.dmdid).to eq 'pageModsBib1'
+    end
+
+    it "shares xml document context with contained pages" do
+      page = issue.page_by_sequence_number(1)
+      expect(page.doc).to be issue.doc
+    end
+
+    it "gets page by sequence number" do
+      page = issue.page_by_sequence_number(1)
+      expect(page.metadata.page_sequence_number).to eq 1
+      expect(page.dmdid).to eq 'pageModsBib1'
+    end
+
+    it "enumerates expected pages" do
+      # enumerate by casting issue to Array
+      pages = issue.to_a
+      expect(pages.size).to eq 1
+      expect(pages[0]).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+      expect(pages[0].metadata.page_sequence_number).to eq 1
+    end
+
+    it "gets size, in page count" do
+      pages = issue.to_a
+      expect(issue.size).to eq pages.size
+      expect(issue.size).to eq issue.dmdids.size
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/ndnp/issue_metadata_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/issue_metadata_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::IssueMetadata do
+  include_context "ndnp fixture setup"
+
+  def construct(path)
+    described_class.new(path)
+  end
+
+  describe "sample fixture 'batch_local'" do
+    it "gets lccn" do
+      issue = construct(issue1)
+      expect(issue.lccn).to eq "sn85058233"
+    end
+
+    it "gets volume" do
+      issue = construct(issue1)
+      expect(issue.volume).to eq "56"
+    end
+
+    it "gets issue" do
+      issue = construct(issue1)
+      expect(issue.issue).to eq "27"
+    end
+
+    it "gets edition" do
+      issue = construct(issue1)
+      expect(issue.edition).to eq "Main Edition"
+    end
+
+    it "gets publication date" do
+      issue = construct(issue1)
+      expect(issue.publication_date).to eq "1935-08-02"
+    end
+
+    it "gets held_by" do
+      issue = construct(issue1)
+      expect(issue.held_by).to eq "University of Utah; Salt Lake City, UT"
+    end
+  end
+
+  describe "sample fixture 'batch_test_ver01" do
+    it "gets lccn" do
+      issue = construct(issue2)
+      expect(issue.lccn).to eq "sn85025202"
+    end
+
+    it "gets volume" do
+      issue = construct(issue2)
+      expect(issue.volume).to eq "2"
+    end
+
+    it "gets issue" do
+      issue = construct(issue2)
+      expect(issue.issue).to eq "4"
+    end
+
+    it "gets edition" do
+      issue = construct(issue2)
+      expect(issue.edition).to eq "1"
+    end
+
+    it "gets publication date" do
+      issue = construct(issue2)
+      expect(issue.publication_date).to eq "1857-02-14"
+    end
+
+    it "gets held_by" do
+      issue = construct(issue2)
+      expect(issue.held_by).to eq "University of Utah, Salt Lake City, UT"
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/ndnp/issue_metadata_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/issue_metadata_spec.rb
@@ -4,70 +4,58 @@ require 'ndnp_shared'
 RSpec.describe NewspaperWorks::Ingest::NDNP::IssueMetadata do
   include_context "ndnp fixture setup"
 
-  def construct(path)
-    described_class.new(path)
-  end
-
   describe "sample fixture 'batch_local'" do
+    let(:issue) { described_class.new(issue1) }
+
     it "gets lccn" do
-      issue = construct(issue1)
       expect(issue.lccn).to eq "sn85058233"
     end
 
     it "gets volume" do
-      issue = construct(issue1)
       expect(issue.volume).to eq "56"
     end
 
     it "gets issue" do
-      issue = construct(issue1)
       expect(issue.issue).to eq "27"
     end
 
     it "gets edition" do
-      issue = construct(issue1)
       expect(issue.edition).to eq "Main Edition"
     end
 
     it "gets publication date" do
-      issue = construct(issue1)
       expect(issue.publication_date).to eq "1935-08-02"
     end
 
     it "gets held_by" do
-      issue = construct(issue1)
       expect(issue.held_by).to eq "University of Utah; Salt Lake City, UT"
     end
   end
 
   describe "sample fixture 'batch_test_ver01" do
+    let(:issue) { described_class.new(issue2) }
+
     it "gets lccn" do
-      issue = construct(issue2)
       expect(issue.lccn).to eq "sn85025202"
     end
 
     it "gets volume" do
-      issue = construct(issue2)
       expect(issue.volume).to eq "2"
     end
 
     it "gets issue" do
-      issue = construct(issue2)
       expect(issue.issue).to eq "4"
     end
 
     it "gets edition" do
-      issue = construct(issue2)
       expect(issue.edition).to eq "1"
     end
 
     it "gets publication date" do
-      issue = construct(issue2)
       expect(issue.publication_date).to eq "1857-02-14"
     end
 
     it "gets held_by" do
-      issue = construct(issue2)
       expect(issue.held_by).to eq "University of Utah, Salt Lake City, UT"
     end
   end

--- a/spec/lib/newspaper_works/ingest/ndnp/page_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/page_ingest_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::PageIngest do
+  include_context "ndnp fixture setup"
+
+  def construct(path, dmdid)
+    described_class.new(path, dmdid)
+  end
+
+  def file_type?(path, ext)
+    path.split('/')[-1].split('.')[-1].casecmp(ext).zero?
+  end
+
+  def includes_file_type(files, ext)
+    files.any? { |path| file_type?(path, ext) }
+  end
+
+  def check_expected_files(page, extensions)
+    files = page.files
+    expect(files.size).to eq extensions.size
+    files.each do |filepath|
+      # each path is normalized to absolute path
+      expect(filepath.start_with?('/')).to be true
+    end
+    extensions.each do |ext|
+      expect(includes_file_type(files, ext)).to be true
+    end
+  end
+
+  describe "sample fixture 'batch_local'" do
+    it "gets metadata" do
+      page = construct(issue1, 'pageModsBib8')
+      expect(page.metadata).to be_a NewspaperWorks::Ingest::NDNP::PageMetadata
+      # uses same Nokogiri document context:
+      expect(page.metadata.doc).to be page.doc
+    end
+
+    it "gets expected files" do
+      page = construct(issue1, 'pageModsBib8')
+      check_expected_files(page, ['tif', 'jp2', 'pdf', 'xml'])
+    end
+  end
+
+  describe "sample fixture 'batch_test_ver01'" do
+    it "gets metadata" do
+      page = construct(issue2, 'pageModsBib1')
+      expect(page.metadata).to be_a NewspaperWorks::Ingest::NDNP::PageMetadata
+      # uses same Nokogiri document context:
+      expect(page.metadata.doc).to be page.doc
+    end
+
+    it "gets expected files" do
+      page = construct(issue2, 'pageModsBib1')
+      check_expected_files(page, ['tif', 'jp2', 'pdf', 'xml'])
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/ndnp/page_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/page_ingest_spec.rb
@@ -4,10 +4,6 @@ require 'ndnp_shared'
 RSpec.describe NewspaperWorks::Ingest::NDNP::PageIngest do
   include_context "ndnp fixture setup"
 
-  def construct(path, dmdid)
-    described_class.new(path, dmdid)
-  end
-
   def file_type?(path, ext)
     path.split('/')[-1].split('.')[-1].casecmp(ext).zero?
   end
@@ -29,29 +25,29 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::PageIngest do
   end
 
   describe "sample fixture 'batch_local'" do
+    let(:page) { described_class.new(issue1, 'pageModsBib8') }
+
     it "gets metadata" do
-      page = construct(issue1, 'pageModsBib8')
       expect(page.metadata).to be_a NewspaperWorks::Ingest::NDNP::PageMetadata
       # uses same Nokogiri document context:
       expect(page.metadata.doc).to be page.doc
     end
 
     it "gets expected files" do
-      page = construct(issue1, 'pageModsBib8')
       check_expected_files(page, ['tif', 'jp2', 'pdf', 'xml'])
     end
   end
 
   describe "sample fixture 'batch_test_ver01'" do
+    let(:page) { described_class.new(issue2, 'pageModsBib1') }
+
     it "gets metadata" do
-      page = construct(issue2, 'pageModsBib1')
       expect(page.metadata).to be_a NewspaperWorks::Ingest::NDNP::PageMetadata
       # uses same Nokogiri document context:
       expect(page.metadata.doc).to be page.doc
     end
 
     it "gets expected files" do
-      page = construct(issue2, 'pageModsBib1')
       check_expected_files(page, ['tif', 'jp2', 'pdf', 'xml'])
     end
   end

--- a/spec/lib/newspaper_works/ingest/ndnp/page_metadata_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/page_metadata_spec.rb
@@ -4,70 +4,56 @@ require 'ndnp_shared'
 RSpec.describe NewspaperWorks::Ingest::NDNP::PageMetadata do
   include_context "ndnp fixture setup"
 
-  def construct(path, dmdid)
-    described_class.new(path, nil, dmdid)
-  end
-
   describe "sample fixture 'batch_local'" do
+    let(:page1) { described_class.new(issue1, nil, 'pageModsBib8') }
+    let(:page2) { described_class.new(issue1, nil, 'pageModsBib6') }
+
     it "gets expected page number as String" do
-      page = construct(issue1, 'pageModsBib8')
-      expect(page.page_number).to eq "1"
-      page = construct(issue1, 'pageModsBib6')
-      expect(page.page_number).to eq "2"
+      expect(page1.page_number).to eq "1"
+      expect(page2.page_number).to eq "2"
     end
 
     it "gets expected sequence number as Integer" do
-      page = construct(issue1, 'pageModsBib8')
-      expect(page.page_sequence_number).to eq 1
-      page = construct(issue1, 'pageModsBib6')
-      expect(page.page_sequence_number).to eq 2
+      expect(page1.page_sequence_number).to eq 1
+      expect(page2.page_sequence_number).to eq 2
     end
 
     it "gets expected width from ALTO as Integer " do
-      page = construct(issue1, 'pageModsBib8')
-      expect(page.width).to eq 18_352
-      page = construct(issue1, 'pageModsBib6')
-      expect(page.width).to eq 18_200
+      expect(page1.width).to eq 18_352
+      expect(page2.width).to eq 18_200
     end
 
     it "gets expected height from ALTO as Integer " do
-      page = construct(issue1, 'pageModsBib8')
-      expect(page.height).to eq 28_632
-      page = construct(issue1, 'pageModsBib6')
-      expect(page.height).to eq 28_872
+      expect(page1.height).to eq 28_632
+      expect(page2.height).to eq 28_872
     end
 
     it "gets identifier from ALTO as primary file name" do
-      page = construct(issue1, 'pageModsBib8')
-      expect(page.identifier).to eq "/mnt/nash.iarchives.com/data01/jobq/root/projects/production/LeanProcessing/UofU/Park_Record/Park_Record_Set01/tpr_19350705-19380630/ocr/0657b.tif"
-      page = construct(issue1, 'pageModsBib6')
-      expect(page.identifier).to eq "/mnt/nash.iarchives.com/data01/jobq/root/projects/production/LeanProcessing/UofU/Park_Record/Park_Record_Set01/tpr_19350705-19380630/ocr/0656a.tif"
+      expect(page1.identifier).to eq "/mnt/nash.iarchives.com/data01/jobq/root/projects/production/LeanProcessing/UofU/Park_Record/Park_Record_Set01/tpr_19350705-19380630/ocr/0657b.tif"
+      expect(page2.identifier).to eq "/mnt/nash.iarchives.com/data01/jobq/root/projects/production/LeanProcessing/UofU/Park_Record/Park_Record_Set01/tpr_19350705-19380630/ocr/0656a.tif"
     end
   end
 
   describe "sample fixture 'batch_test_ver01" do
+    let(:page) { described_class.new(issue2, nil, 'pageModsBib1') }
+
     it "returns nil page number for page without one" do
-      page = construct(issue2, 'pageModsBib1')
       expect(page.page_number).to eq nil
     end
 
     it "gets expected sequence number as Integer" do
-      page = construct(issue2, 'pageModsBib1')
       expect(page.page_sequence_number).to eq 1
     end
 
     it "gets expected width from ALTO as Integer " do
-      page = construct(issue2, 'pageModsBib1')
       expect(page.width).to eq 21_464
     end
 
     it "gets expected height from ALTO as Integer " do
-      page = construct(issue2, 'pageModsBib1')
       expect(page.height).to eq 30_268
     end
 
     it "gets identifier from ALTO as primary file name" do
-      page = construct(issue2, 'pageModsBib1')
       expect(page.identifier).to eq "././0225.tif"
     end
   end

--- a/spec/lib/newspaper_works/ingest/ndnp/page_metadata_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/page_metadata_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::PageMetadata do
+  include_context "ndnp fixture setup"
+
+  def construct(path, dmdid)
+    described_class.new(path, nil, dmdid)
+  end
+
+  describe "sample fixture 'batch_local'" do
+    it "gets expected page number as String" do
+      page = construct(issue1, 'pageModsBib8')
+      expect(page.page_number).to eq "1"
+      page = construct(issue1, 'pageModsBib6')
+      expect(page.page_number).to eq "2"
+    end
+
+    it "gets expected sequence number as Integer" do
+      page = construct(issue1, 'pageModsBib8')
+      expect(page.page_sequence_number).to eq 1
+      page = construct(issue1, 'pageModsBib6')
+      expect(page.page_sequence_number).to eq 2
+    end
+
+    it "gets expected width from ALTO as Integer " do
+      page = construct(issue1, 'pageModsBib8')
+      expect(page.width).to eq 18_352
+      page = construct(issue1, 'pageModsBib6')
+      expect(page.width).to eq 18_200
+    end
+
+    it "gets expected height from ALTO as Integer " do
+      page = construct(issue1, 'pageModsBib8')
+      expect(page.height).to eq 28_632
+      page = construct(issue1, 'pageModsBib6')
+      expect(page.height).to eq 28_872
+    end
+
+    it "gets identifier from ALTO as primary file name" do
+      page = construct(issue1, 'pageModsBib8')
+      expect(page.identifier).to eq "/mnt/nash.iarchives.com/data01/jobq/root/projects/production/LeanProcessing/UofU/Park_Record/Park_Record_Set01/tpr_19350705-19380630/ocr/0657b.tif"
+      page = construct(issue1, 'pageModsBib6')
+      expect(page.identifier).to eq "/mnt/nash.iarchives.com/data01/jobq/root/projects/production/LeanProcessing/UofU/Park_Record/Park_Record_Set01/tpr_19350705-19380630/ocr/0656a.tif"
+    end
+  end
+
+  describe "sample fixture 'batch_test_ver01" do
+    it "returns nil page number for page without one" do
+      page = construct(issue2, 'pageModsBib1')
+      expect(page.page_number).to eq nil
+    end
+
+    it "gets expected sequence number as Integer" do
+      page = construct(issue2, 'pageModsBib1')
+      expect(page.page_sequence_number).to eq 1
+    end
+
+    it "gets expected width from ALTO as Integer " do
+      page = construct(issue2, 'pageModsBib1')
+      expect(page.width).to eq 21_464
+    end
+
+    it "gets expected height from ALTO as Integer " do
+      page = construct(issue2, 'pageModsBib1')
+      expect(page.height).to eq 30_268
+    end
+
+    it "gets identifier from ALTO as primary file name" do
+      page = construct(issue2, 'pageModsBib1')
+      expect(page.identifier).to eq "././0225.tif"
+    end
+  end
+end

--- a/spec/ndnp_shared.rb
+++ b/spec/ndnp_shared.rb
@@ -5,6 +5,7 @@ RSpec.shared_context "ndnp fixture setup", shared_context: :metadata do
     File.join(NewspaperWorksFixtures.file_fixtures, 'ndnp')
   end
 
+  # `batch_local` example issue:
   let(:issue1) do
     File.join(
       ndnp_fixture_path,
@@ -12,6 +13,7 @@ RSpec.shared_context "ndnp fixture setup", shared_context: :metadata do
     )
   end
 
+  # `batch_test_ver01` example issue:
   let(:issue2) do
     File.join(
       ndnp_fixture_path,

--- a/spec/ndnp_shared.rb
+++ b/spec/ndnp_shared.rb
@@ -1,0 +1,21 @@
+require 'newspaper_works_fixtures'
+
+RSpec.shared_context "ndnp fixture setup", shared_context: :metadata do
+  let(:ndnp_fixture_path) do
+    File.join(NewspaperWorksFixtures.file_fixtures, 'ndnp')
+  end
+
+  let(:issue1) do
+    File.join(
+      ndnp_fixture_path,
+      'batch_local/sn85058233/17082901001/1935080201/1935080201.xml'
+    )
+  end
+
+  let(:issue2) do
+    File.join(
+      ndnp_fixture_path,
+      'batch_test_ver01/data/sn85025202/00279557281/1857021401/1857021401.xml'
+    )
+  end
+end


### PR DESCRIPTION
This branch/PR implements a model for issue<>--page object traversal for access to issues, pages, and respective files+metadata, given a path to an issue XML file (mets/mods) for NDNP.

An (untested) example shows in more narrative form (than included tests) how this might be used: see this [gist](https://gist.github.com/seanupton/aab58b96df3c6f0a02d07c221b57b4a2).