### PR TITLE
Metadata facet behavior

### DIFF
--- a/app/indexers/concerns/newspaper_works/indexes_place_of_publication.rb
+++ b/app/indexers/concerns/newspaper_works/indexes_place_of_publication.rb
@@ -22,9 +22,10 @@ module NewspaperWorks
     # @param solr_doc [Hash] the hash of field data to be pushed to Solr
     def add_geodata_fields(solr_doc)
       %w[city county state country].each do |place|
-        solr_doc["place_of_publication_#{place}_ssim"] ||= []
+        solr_doc["place_of_publication_#{place}_sim"] ||= []
       end
       solr_doc['place_of_publication_label_tesim'] ||= []
+      solr_doc['place_of_publication_label_sim'] ||= []
       solr_doc['place_of_publication_llsim'] ||= []
     end
 
@@ -38,12 +39,13 @@ module NewspaperWorks
       county = geodata['adminName2']
       state = geodata['adminName1']
       country = geodata['countryName']
-      solr_doc['place_of_publication_city_ssim'] << city
-      solr_doc['place_of_publication_county_ssim'] << county
-      solr_doc['place_of_publication_state_ssim'] << state
-      solr_doc['place_of_publication_country_ssim'] << country
+      solr_doc['place_of_publication_city_sim'] << city
+      solr_doc['place_of_publication_county_sim'] << county
+      solr_doc['place_of_publication_state_sim'] << state
+      solr_doc['place_of_publication_country_sim'] << country
       display_name = [city, state, country].compact.join(', ')
       solr_doc['place_of_publication_label_tesim'] << display_name
+      solr_doc['place_of_publication_label_sim'] << display_name
       return unless geodata['lat'] && geodata['lng']
       # TODO: this should use a Solr location_rpt field type
       solr_doc['place_of_publication_llsim'] << "#{geodata['lat']},#{geodata['lng']}"

--- a/app/indexers/newspaper_article_indexer.rb
+++ b/app/indexers/newspaper_article_indexer.rb
@@ -3,13 +3,14 @@
 class NewspaperArticleIndexer < NewspaperWorks::NewspaperCoreIndexer
   def generate_solr_document
     super.tap do |solr_doc|
-      # index the labels for the genre URIs
+      # index the labels for the genre URIs, as searchable and facetable
       article_genre_service = Hyrax::ArticleGenreService.new
       genre_labels = []
       object.genre.each do |value|
         genre_labels << article_genre_service.label(value) { value }
       end
       solr_doc['genre_tesim'] = genre_labels.presence
+      solr_doc['genre_sim'] = genre_labels.presence
     end
   end
 end

--- a/app/models/concerns/newspaper_works/newspaper_core_metadata.rb
+++ b/app/models/concerns/newspaper_works/newspaper_core_metadata.rb
@@ -33,7 +33,7 @@ module NewspaperWorks
         predicate: ::RDF::Vocab::Identifiers.issn,
         multiple: false
       ) do |index|
-        index.as :stored_searchable
+        index.as :stored_searchable, :facetable
       end
 
       # - LCCN
@@ -42,7 +42,7 @@ module NewspaperWorks
         predicate: ::RDF::Vocab::Identifiers.lccn,
         multiple: false
       ) do |index|
-        index.as :stored_searchable
+        index.as :stored_searchable, :facetable
       end
 
       # - OCLC Number
@@ -51,7 +51,7 @@ module NewspaperWorks
         predicate: ::RDF::Vocab::BIBO.oclcnum,
         multiple: false
       ) do |index|
-        index.as :stored_searchable
+        index.as :stored_searchable, :facetable
       end
 
       # Holding location (held by):
@@ -60,7 +60,7 @@ module NewspaperWorks
         predicate: ::RDF::Vocab::BF2.heldBy,
         multiple: false
       ) do |index|
-        index.as :stored_searchable
+        index.as :stored_searchable, :facetable
       end
     end
   end

--- a/app/models/newspaper_article.rb
+++ b/app/models/newspaper_article.rb
@@ -44,7 +44,7 @@ class NewspaperArticle < ActiveFedora::Base
     predicate: ::RDF::Vocab::EDM.hasType,
     multiple: true
   ) do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   # - Author

--- a/app/models/newspaper_article.rb
+++ b/app/models/newspaper_article.rb
@@ -53,7 +53,7 @@ class NewspaperArticle < ActiveFedora::Base
     predicate: ::RDF::Vocab::MARCRelators.aut,
     multiple: true
   ) do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   # - Photographer
@@ -62,7 +62,7 @@ class NewspaperArticle < ActiveFedora::Base
     predicate: ::RDF::Vocab::MARCRelators.pht,
     multiple: true
   ) do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   # - Volume
@@ -98,7 +98,7 @@ class NewspaperArticle < ActiveFedora::Base
     predicate: ::RDF::Vocab::DC.spatial,
     multiple: true
   ) do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   # - Extent

--- a/app/models/newspaper_title.rb
+++ b/app/models/newspaper_title.rb
@@ -64,7 +64,7 @@ class NewspaperTitle < ActiveFedora::Base
     predicate: ::RDF::URI.new('http://rdaregistry.info/Elements/u/P60261'),
     multiple: true
   ) do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   # - Succeeded by
@@ -73,7 +73,7 @@ class NewspaperTitle < ActiveFedora::Base
     predicate: ::RDF::URI.new('http://rdaregistry.info/Elements/u/P60278'),
     multiple: true
   ) do |index|
-    index.as :stored_searchable
+    index.as :stored_searchable, :facetable
   end
 
   # - Publication date start

--- a/lib/generators/newspaper_works/install_generator.rb
+++ b/lib/generators/newspaper_works/install_generator.rb
@@ -9,7 +9,6 @@ module NewspaperWorks
       rake "newspaper_works:install:migrations"
     end
 
-    # rubocop:disable Metrics/MethodLength
     def register_worktypes
       inject_into_file 'config/initializers/hyrax.rb',
                        after: "Hyrax.config do |config|\n" do
@@ -26,7 +25,6 @@ module NewspaperWorks
           "  #== END GENERATED newspaper_works CONFIG ==\n\n"
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def inject_routes
       inject_into_file 'config/routes.rb',
@@ -65,8 +63,9 @@ module NewspaperWorks
       copy_file "config/authorities/newspaper_article_genres.yml"
     end
 
+    # rubocop:disable Metrics/MethodLength
     def add_facets_to_catalog_controller
-      marker = 'config.add_facet_field solr_name("generic_type", :facetable), if: false'
+      marker = 'configure_blacklight do |config|'
       inject_into_file 'app/controllers/catalog_controller.rb', after: marker do
         "\n\n    # NewspaperWorks facet fields\n"\
         "    config.add_facet_field solr_name('place_of_publication_city', :facetable), label: 'Place of publication', limit: 5\n"\
@@ -86,5 +85,6 @@ module NewspaperWorks
         "    config.add_facet_field solr_name('succeeded_by', :facetable), label: 'Succeeded by', if: false\n"
       end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/generators/newspaper_works/install_generator.rb
+++ b/lib/generators/newspaper_works/install_generator.rb
@@ -64,5 +64,27 @@ module NewspaperWorks
       end
       copy_file "config/authorities/newspaper_article_genres.yml"
     end
+
+    def add_facets_to_catalog_controller
+      marker = 'config.add_facet_field solr_name("generic_type", :facetable), if: false'
+      inject_into_file 'app/controllers/catalog_controller.rb', after: marker do
+        "\n    # NewspaperWorks facet fields\n"\
+        "    config.add_facet_field 'place_of_publication_city_ssim', label: 'Place of publication' limit: 5\n"\
+        "    config.add_facet_field 'publication_title_ssi', label: 'Publication title' limit: 5\n"\
+        "    config.add_facet_field solr_name('genre', :facetable), label: 'Article type' limit: 5\n\n"\
+        "    # additional NewspaperWorks fields not displayed in the facet list,\n"\
+        "    # but below definitions give labels to filters for linked metadata\n"\
+        "    config.add_facet_field solr_name('place_of_publication_label', :facetable)', if: false\n"\
+        "    config.add_facet_field solr_name('issn', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('lccn', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('oclcnum', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('held_by', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('author', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('photographer', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('geographic_coverage', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('preceded_by', :facetable), if: false\n"\
+        "    config.add_facet_field solr_name('succeeded_by', :facetable), if: false\n\n"
+      end
+    end
   end
 end

--- a/lib/generators/newspaper_works/install_generator.rb
+++ b/lib/generators/newspaper_works/install_generator.rb
@@ -68,22 +68,22 @@ module NewspaperWorks
     def add_facets_to_catalog_controller
       marker = 'config.add_facet_field solr_name("generic_type", :facetable), if: false'
       inject_into_file 'app/controllers/catalog_controller.rb', after: marker do
-        "\n    # NewspaperWorks facet fields\n"\
-        "    config.add_facet_field 'place_of_publication_city_ssim', label: 'Place of publication' limit: 5\n"\
-        "    config.add_facet_field 'publication_title_ssi', label: 'Publication title' limit: 5\n"\
-        "    config.add_facet_field solr_name('genre', :facetable), label: 'Article type' limit: 5\n\n"\
+        "\n\n    # NewspaperWorks facet fields\n"\
+        "    config.add_facet_field solr_name('place_of_publication_city', :facetable), label: 'Place of publication', limit: 5\n"\
+        "    config.add_facet_field 'publication_title_ssi', label: 'Publication title', limit: 5\n"\
+        "    config.add_facet_field solr_name('genre', :facetable), label: 'Article type', limit: 5\n\n"\
         "    # additional NewspaperWorks fields not displayed in the facet list,\n"\
         "    # but below definitions give labels to filters for linked metadata\n"\
-        "    config.add_facet_field solr_name('place_of_publication_label', :facetable)', if: false\n"\
-        "    config.add_facet_field solr_name('issn', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('lccn', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('oclcnum', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('held_by', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('author', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('photographer', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('geographic_coverage', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('preceded_by', :facetable), if: false\n"\
-        "    config.add_facet_field solr_name('succeeded_by', :facetable), if: false\n\n"
+        "    config.add_facet_field solr_name('place_of_publication_label', :facetable), label: 'Place of publication', if: false\n"\
+        "    config.add_facet_field solr_name('issn', :facetable), label: 'ISSN', if: false\n"\
+        "    config.add_facet_field solr_name('lccn', :facetable), label: 'LCCN', if: false\n"\
+        "    config.add_facet_field solr_name('oclcnum', :facetable), label: 'OCLC #', if: false\n"\
+        "    config.add_facet_field solr_name('held_by', :facetable), label: 'Held by', if: false\n"\
+        "    config.add_facet_field solr_name('author', :facetable), label: 'Author', if: false\n"\
+        "    config.add_facet_field solr_name('photographer', :facetable), label: 'Photographer', if: false\n"\
+        "    config.add_facet_field solr_name('geographic_coverage', :facetable), label: 'Geographic coverage', if: false\n"\
+        "    config.add_facet_field solr_name('preceded_by', :facetable), label: 'Preceded by', if: false\n"\
+        "    config.add_facet_field solr_name('succeeded_by', :facetable), label: 'Succeeded by', if: false\n"
       end
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe CatalogController do
+  describe 'NewspaperWorks::InstallGenerator#add_facets_to_catalog_controller' do
+    subject { described_class.blacklight_config.facet_fields }
+
+    it 'has NewspaperWorks facet fields' do
+      expect(subject['place_of_publication_city_sim']).not_to be_falsey
+      expect(subject['publication_title_ssi'].class).to eq(Blacklight::Configuration::FacetField)
+      expect(subject['genre_sim'].label).to eq('Article type')
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'has definitions for non-displaying facet fields' do
+      expect(subject['place_of_publication_label_sim']).not_to be_falsey
+      expect(subject['issn_sim']).not_to be_falsey
+      expect(subject['lccn_sim']).not_to be_falsey
+      expect(subject['oclcnum_sim']).not_to be_falsey
+      expect(subject['held_by_sim']).not_to be_falsey
+      expect(subject['author_sim']).not_to be_falsey
+      expect(subject['photographer_sim']).not_to be_falsey
+      expect(subject['geographic_coverage_sim']).not_to be_falsey
+      expect(subject['preceded_by_sim']).not_to be_falsey
+      expect(subject['succeeded_by_sim']).not_to be_falsey
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/indexers/concerns/newspaper_works/indexes_place_of_publication_spec.rb
+++ b/spec/indexers/concerns/newspaper_works/indexes_place_of_publication_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NewspaperWorks::IndexesPlaceOfPublication do
       test_indexer.index_pop(ntitle, solr_doc)
     end
     it 'sets the geodata fields correctly' do
-      expect(solr_doc['place_of_publication_state_ssim'].first).not_to be_falsey
+      expect(solr_doc['place_of_publication_state_sim'].first).not_to be_falsey
       expect(solr_doc['place_of_publication_llsim'].first).not_to be_falsey
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe NewspaperWorks::IndexesPlaceOfPublication do
     let(:solr_doc) { {} }
     before { test_indexer.add_geodata_fields(solr_doc) }
     it 'adds the geodata fields' do
-      expect(solr_doc['place_of_publication_county_ssim'].class).to eq(Array)
+      expect(solr_doc['place_of_publication_county_sim'].class).to eq(Array)
       expect(solr_doc['place_of_publication_label_tesim'].class).to eq(Array)
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe NewspaperWorks::IndexesPlaceOfPublication do
       test_indexer.index_pop_geodata(geodata, solr_doc)
     end
     it 'parses the geodata correctly' do
-      expect(solr_doc['place_of_publication_city_ssim']).to include('Salem')
+      expect(solr_doc['place_of_publication_city_sim']).to include('Salem')
       expect(solr_doc['place_of_publication_llsim']).to include('42.51954,-70.89672')
     end
   end

--- a/spec/indexers/newspaper_article_indexer_spec.rb
+++ b/spec/indexers/newspaper_article_indexer_spec.rb
@@ -13,12 +13,17 @@ RSpec.describe NewspaperArticleIndexer do
   describe '#generate_solr_document' do
     subject { indexer.generate_solr_document }
 
+    it 'adds the correct fields to the Solr document' do
+      expect(subject['genre_tesim']).not_to be_falsey
+      expect(subject['genre_sim']).not_to be_falsey
+    end
+
     it 'indexes genre terms with a URI correctly' do
       expect(subject['genre_tesim']).to include('Advertisement')
     end
 
     it 'indexes genre terms without a URI correctly' do
-      expect(subject['genre_tesim']).to include('FOO')
+      expect(subject['genre_sim']).to include('FOO')
     end
   end
 end

--- a/spec/indexers/newspaper_works/newspaper_core_indexer_spec.rb
+++ b/spec/indexers/newspaper_works/newspaper_core_indexer_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe NewspaperWorks::NewspaperCoreIndexer do
     subject { indexer.generate_solr_document }
     it 'processes place_of_publication field' do
       expect(subject['place_of_publication_tesim']).to include(geonames_uri)
-      expect(subject['place_of_publication_city_ssim']).to include('Salem')
-      expect(subject['place_of_publication_state_ssim']).to include('Massachusetts')
+      expect(subject['place_of_publication_city_sim']).to include('Salem')
+      expect(subject['place_of_publication_state_sim']).to include('Massachusetts')
     end
   end
 end


### PR DESCRIPTION
This PR:
* adds some configuration to the local app's `CatalogController` to support linking of metadata values in the item show view display. (#109)
* adds facets for Place of publication, Publication title, and Article type (#87)
* updates some properties to add the `index.as: :facetable` option to support above behavior