### PR TITLE
Alto extraction

### DIFF
--- a/app/services/newspaper_works/text_extraction_derivative_service.rb
+++ b/app/services/newspaper_works/text_extraction_derivative_service.rb
@@ -6,7 +6,15 @@ module NewspaperWorks
       @txt_path = nil
     end
 
-    def create_derivatives(filename)
+    def create_derivatives(src)
+      from_alto = NewspaperWorks::TextFormsFromExistingALTOService.new(
+        file_set
+      )
+      return from_alto.create_derivatives(src) unless from_alto.alto_path.nil?
+      create_derivatives_from_ocr(filename)
+    end
+
+    def create_derivatives_from_ocr(filename)
       @source_path = filename
       # prepare destination directory for ALTO (as .xml files):
       @alto_path = prepare_path('xml')

--- a/app/services/newspaper_works/text_extraction_derivative_service.rb
+++ b/app/services/newspaper_works/text_extraction_derivative_service.rb
@@ -7,11 +7,11 @@ module NewspaperWorks
     end
 
     def create_derivatives(src)
-      from_alto = NewspaperWorks::TextFormsFromExistingALTOService.new(
+      from_alto = NewspaperWorks::TextFormatsFromALTOService.new(
         file_set
       )
       return from_alto.create_derivatives(src) unless from_alto.alto_path.nil?
-      create_derivatives_from_ocr(filename)
+      create_derivatives_from_ocr(src)
     end
 
     def create_derivatives_from_ocr(filename)

--- a/app/services/newspaper_works/text_formats_from_alto_service.rb
+++ b/app/services/newspaper_works/text_formats_from_alto_service.rb
@@ -21,6 +21,7 @@ module NewspaperWorks
     end
 
     def nonempty_file?(path)
+      return false if path.nil?
       return false unless File.exist?(path)
       !File.size.zero?
     end
@@ -29,7 +30,7 @@ module NewspaperWorks
       # check first for existing, non-empty derivative data:
       path = derivative_path_factory.derivative_path_for_reference(
         @file_set,
-        destination
+        'xml'
       )
       return path if nonempty_file?(path)
       # if there was no derivative yet, there might be one in-transit from
@@ -37,7 +38,7 @@ module NewspaperWorks
       path = NewspaperWorks::DerivativeAttachment.where(
         fileset_id: @file_set.id,
         destination_name: 'xml'
-      ).pluck(:path).uniq
+      ).pluck(:path).uniq.first
       path if nonempty_file?(path)
     end
 

--- a/app/services/newspaper_works/text_formats_from_alto_service.rb
+++ b/app/services/newspaper_works/text_formats_from_alto_service.rb
@@ -1,0 +1,64 @@
+module NewspaperWorks
+  # Plugin to make text format derviatives (JSON, plain-text) from ALTO,
+  #   either existing derivative, or an impending attachment.
+  #   NOTE: to keep this from conflicting with TextExtractionDerivativeService,
+  #         this class should be invoked by it, not PluggableDerivativeService.
+  class TextFormatsFromALTOService < NewspaperPageDerivativeService
+    TARGET_EXT = 'tiff'.freeze
+
+    def save_derivative(destination, data)
+      # Load/prepare base of "pairtree" dir structure for extension, fileset
+      prepare_path(destination)
+      #
+      save_path = derivative_path_factory.derivative_path_for_reference(
+        @file_set,
+        destination
+      )
+      # Write data as UTF-8 encoded text
+      File.open(save_path, "w:UTF-8") do |f|
+        f.write(data)
+      end
+    end
+
+    def nonempty_file?(path)
+      return false unless File.exist?(path)
+      !File.size.zero?
+    end
+
+    def alto_path
+      # check first for existing, non-empty derivative data:
+      path = derivative_path_factory.derivative_path_for_reference(
+        @file_set,
+        destination
+      )
+      return path if nonempty_file?(path)
+      # if there was no derivative yet, there might be one in-transit from
+      #   an ingest, so check for that, and use its source if applicable:
+      path = NewspaperWorks::DerivativeAttachment.where(
+        fileset_id: @file_set.id,
+        destination_name: 'xml'
+      ).pluck(:path).uniq
+      path if nonempty_file?(path)
+    end
+
+    def alto
+      path = alto_path
+      File.read(path, encoding: 'UTF-8') unless path.nil?
+    end
+
+    def create_derivatives(_filename)
+      # as this plugin makes derivatives of derivative, _filename is ignored
+      source_file = alto
+      return if source_file.nil?
+      # ALTOReader is responsible for transcoding, this class just saves result
+      reader = NewspaperWorks::TextExtraction::ALTOReader.new(source_file)
+      save_derivative('json', reader.json)
+      save_derviative('txt', reader.text)
+    end
+
+    def cleanup_derivatives(*args)
+      # do nothing here; NewspaperWorks::TextExtractionDerivativeService
+      # has this job instead for cleaning ALTO, JSON, TXT.
+    end
+  end
+end

--- a/lib/newspaper_works/data/work_derivatives.rb
+++ b/lib/newspaper_works/data/work_derivatives.rb
@@ -165,6 +165,19 @@ module NewspaperWorks
         load_paths
       end
 
+      # Load all paths/names to @paths once, upon first access
+      def load_paths
+        fsid = fileset_id
+        if fsid.nil?
+          @paths = {}
+          return
+        end
+        # list of paths
+        paths = path_factory.derivatives_for_reference(fsid)
+        # names from paths
+        @paths = paths.map { |e| [path_destination_name(e), e] }.to_h
+      end
+
       # path to existing derivative file for destination name
       # @param name [String] destination name, usually file extension
       # @return [String, NilClass] path (or nil)
@@ -266,19 +279,6 @@ module NewspaperWorks
           end
           # note: there is deliberately no attempt to "unlog" primary
           #   file relation, as leaving it should have no side-effect.
-        end
-
-        # Load all paths/names to @paths once, upon first access
-        def load_paths
-          fsid = fileset_id
-          if fsid.nil?
-            @paths = {}
-            return
-          end
-          # list of paths
-          paths = path_factory.derivatives_for_reference(fsid)
-          # names from paths
-          @paths = paths.map { |e| [path_destination_name(e), e] }.to_h
         end
 
         def path_destination_name(path)

--- a/spec/services/newspaper_works/text_extraction_derivative_service_spec.rb
+++ b/spec/services/newspaper_works/text_extraction_derivative_service_spec.rb
@@ -1,22 +1,29 @@
 require 'nokogiri'
 require 'spec_helper'
+require 'misc_shared'
 
 RSpec.describe NewspaperWorks::TextExtractionDerivativeService do
+  include_context "shared setup"
+
   let(:valid_file_set) do
     file_set = FileSet.new
     file_set.save!(validate: false)
     file_set
   end
 
+  let(:work) do
+    work = NewspaperPage.create(title: ["Hello"])
+    work.members << valid_file_set
+    work.save!
+  end
+
+  let(:minimal_alto) do
+    File.join(fixture_path, 'minimal-alto.xml')
+  end
+
   let(:altoxsd) do
     xsdpath = File.join(fixture_path, 'alto-2-0.xsd')
     Nokogiri::XML::Schema(File.read(xsdpath))
-  end
-
-  let(:fixture_path) do
-    File.join(
-      NewspaperWorks::GEM_PATH, 'spec', 'fixtures', 'files'
-    )
   end
 
   describe "Creates ALTO derivative" do
@@ -50,6 +57,26 @@ RSpec.describe NewspaperWorks::TextExtractionDerivativeService do
       json_path = expected_path(valid_file_set, 'json')
       loaded_result = JSON.parse(File.read(json_path))
       expect(loaded_result['words'].length).to be > 1
+    end
+
+    it "usually uses OCR, when no existing text" do
+      service = described_class.new(valid_file_set)
+      # here, service will delegate create_derivatives to OCR impl method:
+      expect(service).to receive(:create_derivatives_from_ocr)
+      service.create_derivatives(source_image('ocr_mono.tiff'))
+    end
+
+    it "defers to existing ALTO sources, when present" do
+      # Attach some ALTO to a work
+      derivatives = NewspaperWorks::Data::WorkDerivatives.of(
+        work,
+        valid_file_set
+      )
+      derivatives.attach(minimal_alto, 'xml')
+      # In this case, service will not call the OCR implementation method:
+      service = described_class.new(valid_file_set)
+      expect(service).not_to receive(:create_derivatives_from_ocr)
+      service.create_derivatives(source_image('ocr_mono.tiff'))
     end
   end
 end

--- a/spec/services/newspaper_works/text_formats_from_alto_service_spec.rb
+++ b/spec/services/newspaper_works/text_formats_from_alto_service_spec.rb
@@ -1,0 +1,60 @@
+require 'nokogiri'
+require 'spec_helper'
+require 'misc_shared'
+
+RSpec.describe NewspaperWorks::TextFormatsFromALTOService do
+  include_context "shared setup"
+
+  let(:valid_file_set) do
+    file_set = FileSet.new
+    file_set.save!(validate: false)
+    file_set
+  end
+
+  let(:work) do
+    work = NewspaperPage.create(title: ["Hello"])
+    work.members << valid_file_set
+    work.save!
+  end
+
+  let(:minimal_alto) do
+    File.join(fixture_path, 'minimal-alto.xml')
+  end
+
+  def log_incoming_attachment(fsid)
+    NewspaperWorks::DerivativeAttachment.create!(
+      fileset_id: fsid,
+      path: minimal_alto,
+      destination_name: 'xml'
+    )
+  end
+
+  def derivatives_of(work, fileset)
+    NewspaperWorks::Data::WorkDerivatives.of(work, fileset)
+  end
+
+  describe "Saves other formats from ALTO" do
+    it "saves JSON, text from existing ALTO derivative" do
+      derivatives = derivatives_of(work, valid_file_set)
+      expect(derivatives.keys.size).to eq 0
+      derivatives.attach(minimal_alto, 'xml')
+      expect(derivatives.keys.size).to eq 1
+      service = described_class.new(valid_file_set)
+      service.create_derivatives('/some/random/primary/path/does_not/matter')
+      derivatives.load_paths
+      expect(derivatives.keys.size).to eq 3
+      expect(derivatives.keys).to include 'json', 'txt'
+    end
+
+    it "saves JSON, text from incoming ALTO derivative" do
+      derivatives = derivatives_of(work, valid_file_set)
+      expect(derivatives.keys.size).to eq 0
+      log_incoming_attachment(valid_file_set.id)
+      service = described_class.new(valid_file_set)
+      service.create_derivatives('/some/random/primary/path/does_not/matter')
+      # reload keys to check derivatives:
+      derivatives.load_paths
+      expect(derivatives.keys).to include 'json', 'txt'
+    end
+  end
+end


### PR DESCRIPTION
Adds a new plugin, `NewspaperWorks::TextFormatsFromAltoService`, which is responsible from saving JSON (word coordinate) and plain-text from ALTO derivative data, from either:

1. Existing ALTO derivative attached to work;
2. Incoming ALTO derivative with path to source logged in RDBMS (via NewspaperWorks::DerivativeAttachment AR model/table), if no existing derivative is yet attached.

**When merged, this should complete the work described in issue #107.**

## Implementation notes:

* Unlike other "derivative service" plugin components, this plugin is not registered for use by `NewspaperWorks::PluggableDerivativeService` — instead it is called by `NewspaperWorks::TextExtractionDerivativeService`, which now first attempts to use existing ALTO before trying to attempt OCR on primary file asset.
* Current tests only verify against minimal ALTO, and to not at this time attempt to use either sample NDNP ALTO in newspaper_works, nor data from `newspaper_works_fixtures`.  These fixtures can, however, be manually tested in a rails console.

## See also:

* Previously merged PR #60 (implements the `NewspaperWorks::AltoReader` class that does the actual transcoding of ALTO to JSON, plain-text).