### PR TITLE
Revised NDNP batch enumeration, reel/container models

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-# version: 6.0.0
+version: 7.7.1
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/lib/newspaper_works/ingest/ndnp.rb
+++ b/lib/newspaper_works/ingest/ndnp.rb
@@ -3,6 +3,7 @@ require 'newspaper_works/ingest/ndnp/page_ingest'
 require 'newspaper_works/ingest/ndnp/page_metadata'
 require 'newspaper_works/ingest/ndnp/issue_ingest'
 require 'newspaper_works/ingest/ndnp/issue_metadata'
+require 'newspaper_works/ingest/ndnp/container_metadata'
 
 module NewspaperWorks
   module Ingest

--- a/lib/newspaper_works/ingest/ndnp.rb
+++ b/lib/newspaper_works/ingest/ndnp.rb
@@ -3,6 +3,7 @@ require 'newspaper_works/ingest/ndnp/page_ingest'
 require 'newspaper_works/ingest/ndnp/page_metadata'
 require 'newspaper_works/ingest/ndnp/issue_ingest'
 require 'newspaper_works/ingest/ndnp/issue_metadata'
+require 'newspaper_works/ingest/ndnp/container_ingest'
 require 'newspaper_works/ingest/ndnp/container_metadata'
 
 module NewspaperWorks

--- a/lib/newspaper_works/ingest/ndnp.rb
+++ b/lib/newspaper_works/ingest/ndnp.rb
@@ -5,6 +5,7 @@ require 'newspaper_works/ingest/ndnp/issue_ingest'
 require 'newspaper_works/ingest/ndnp/issue_metadata'
 require 'newspaper_works/ingest/ndnp/container_ingest'
 require 'newspaper_works/ingest/ndnp/container_metadata'
+require 'newspaper_works/ingest/ndnp/batch_xml_ingest'
 
 module NewspaperWorks
   module Ingest

--- a/lib/newspaper_works/ingest/ndnp/batch_xml_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/batch_xml_ingest.rb
@@ -4,8 +4,12 @@ module NewspaperWorks
   module Ingest
     module NDNP
       class BatchXMLIngest
+        include Enumerable
         include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
         attr_accessor :container_paths, :issue_paths, :path
+
+        delegate :size, to: :issue_paths
 
         def initialize(path)
           @path = path
@@ -33,6 +37,12 @@ module NewspaperWorks
 
         def containers
           container_paths.map { |path| get(path) }
+        end
+
+        def each
+          @issue_paths.each do |path|
+            yield get_issue(path)
+          end
         end
 
         private

--- a/lib/newspaper_works/ingest/ndnp/batch_xml_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/batch_xml_ingest.rb
@@ -1,0 +1,62 @@
+require 'nokogiri'
+
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class BatchXMLIngest
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+        attr_accessor :container_paths, :issue_paths, :path
+
+        def initialize(path)
+          @path = path
+          load_doc
+          @container_paths = xpath('//ndnp:batch//ndnp:reel').map do |e|
+            normalize_path(e.text)
+          end
+          @issue_paths = xpath('//ndnp:batch//ndnp:issue').map do |e|
+            normalize_path(e.text)
+          end
+        end
+
+        def name
+          xpath('//ndnp:batch').first.attributes['name'].value
+        end
+
+        def get(path)
+          return get_issue(path) if issue_paths.include?(path)
+          get_container(path)
+        end
+
+        def issues
+          issue_paths.map { |path| get(path) }
+        end
+
+        def containers
+          container_paths.map { |path| get(path) }
+        end
+
+        private
+
+          def get_issue(path)
+            NewspaperWorks::Ingest::NDNP::IssueIngest.new(path)
+          end
+
+          def get_container(path)
+            NewspaperWorks::Ingest::NDNP::ContainerIngest.new(path)
+          end
+
+          def xpath(expr)
+            ns = {
+              ndnp: 'http://www.loc.gov/ndnp',
+              NDNP: 'http://www.loc.gov/ndnp'
+            }
+            @doc.xpath(expr, **ns)
+          end
+
+          def load_doc
+            @doc = Nokogiri::XML(File.open(path))
+          end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/container_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/container_ingest.rb
@@ -2,18 +2,20 @@ module NewspaperWorks
   module Ingest
     module NDNP
       class ContainerIngest
-        # Enumerable of PageIngest objects for pages on reel
+        # Enumerable of IssueIngest objects for issues in pages
         include Enumerable
         include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
 
-        attr_accessor :path, :doc, :dmdids
+        attr_accessor :path, :doc, :dmdids, :issue_paths
 
         def initialize(path)
           @path = path
           @doc = nil
           @metadata = nil
-          # Enumeration based on list of DMDID loaded by load_doc
+          # identifiers of control images, which we make accessible, but are
+          #   not the primary focus of enumeration:
           @dmdids = nil
+          @issue_paths = []
           load_doc
         end
 
@@ -29,18 +31,29 @@ module NewspaperWorks
           metadata.reel_number
         end
 
+        # Return control image as PageIngest object.
+        #   These objects will not have pagination/sequence data, but
+        #   will provide an equivalent programmatic interface for file access
+        #   of control images, as one would access normal page files.
+        # @return [NewspaperWorks::Ingest::NDNP::PageIngest]
         def page_by_dmdid(dmdid)
           NewspaperWorks::Ingest::NDNP::PageIngest.new(@path, dmdid, self)
         end
 
+        # Get IssueIngest object, given path to its XML
+        # return [NewspaperWorks::Ingest::NDNP::IssueIngest]
+        def issue_by_path(path)
+          NewspaperWorks::Ingest::NDNP::IssueIngest.new(path)
+        end
+
         def each
-          @dmdids.each do |dmdid|
-            yield page_by_dmdid(dmdid)
+          @issue_paths.each do |path|
+            yield issue_by_path(path)
           end
         end
 
         def size
-          @dmdids.size
+          @issue_paths.size
         end
 
         def metadata
@@ -60,7 +73,25 @@ module NewspaperWorks
                 "mets:div[@TYPE='np:target']",
               mets: 'http://www.loc.gov/METS/'
             )
+            # identifiers for reel control images:
             @dmdids = page_divs.map { |div| div.attr('DMDID') }
+            load_issue_paths
+          end
+
+          # Load instance attribute for issue paths,
+          #   based on listing of directory in which reel XML is present.
+          #   This is done without context of batch xml,
+          #   with file name expectations based on convention,
+          #   as expressed in NDNP technical guidelines,
+          #   which presume that the issue XML file name will (sans extension)
+          #   match directory name for the issue, in date+edition syntax.
+          def load_issue_paths
+            issue_dir_paths = Dir["#{File.dirname(path)}/*/"].select do |v|
+              !File.basename(v).match(/^[0-9]+$/).nil?
+            end
+            @issue_paths = issue_dir_paths.map do |path|
+              File.join(path, "#{File.basename(path)}.xml")
+            end
           end
       end
     end

--- a/lib/newspaper_works/ingest/ndnp/container_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/container_ingest.rb
@@ -1,0 +1,68 @@
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class ContainerIngest
+        # Enumerable of PageIngest objects for pages on reel
+        include Enumerable
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
+        attr_accessor :path, :doc, :dmdids
+
+        def initialize(path)
+          @path = path
+          @doc = nil
+          @metadata = nil
+          # Enumeration based on list of DMDID loaded by load_doc
+          @dmdids = nil
+          load_doc
+        end
+
+        def inspect
+          format(
+            "<#{self.class}:0x000000000%<oid>x\n" \
+              "\tpath: '#{path}',\n",
+            oid: object_id << 1
+          )
+        end
+
+        def identifier
+          metadata.reel_number
+        end
+
+        def page_by_dmdid(dmdid)
+          NewspaperWorks::Ingest::NDNP::PageIngest.new(@path, dmdid, self)
+        end
+
+        def each
+          @dmdids.each do |dmdid|
+            yield page_by_dmdid(dmdid)
+          end
+        end
+
+        def size
+          @dmdids.size
+        end
+
+        def metadata
+          return @metadata unless @metadata.nil?
+          @metadata = NewspaperWorks::Ingest::NDNP::ContainerMetadata.new(
+            path,
+            self
+          )
+        end
+
+        private
+
+          def load_doc
+            @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
+            page_divs = doc.xpath(
+              "//mets:structMap/mets:div[@TYPE='np:reel']/" \
+                "mets:div[@TYPE='np:target']",
+              mets: 'http://www.loc.gov/METS/'
+            )
+            @dmdids = page_divs.map { |div| div.attr('DMDID') }
+          end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/container_metadata.rb
+++ b/lib/newspaper_works/ingest/ndnp/container_metadata.rb
@@ -1,0 +1,78 @@
+module NewspaperWorks
+  module Ingest
+    module NDNP
+      class ContainerMetadata
+        include NewspaperWorks::Ingest::NDNP::NDNPMetsHelper
+
+        attr_accessor :path, :doc
+
+        def initialize(path, parent = nil)
+          @path = path
+          @parent = parent
+          @doc = nil
+          load_doc
+        end
+
+        def inspect
+          format(
+            "<#{self.class}:0x000000000%<oid>x\n" \
+              "\tpath: '#{path}',\n",
+            oid: object_id << 1
+          )
+        end
+
+        # Reel Number (NDNP-mandatory)
+        # @return [String] a serial number string for reel, may correspond
+        #   to an issued barcode
+        def reel_number
+          xpath("//mods:identifier[@type='reel number']").first.text
+        end
+
+        # Original Source Repository (NDNP-mandatory)
+        # @return [String]
+        def held_by
+          xpath("//mods:physicalLocation").first['displayLabel']
+        end
+
+        # Media genre/form (Page Physical Description, e.g. "microform")
+        #   NDNP Mandatory.
+        # @return [String]
+        def genre
+          form = xpath('//mods:physicalDescription/MODS:form').first
+          form.attributes['type'].value
+        end
+
+        # Titles (on Reel) (optional)
+        # @return [String] title
+        def title
+          techmd('ndnp:titles')
+        end
+
+        # Start Date (optional)
+        # @return [String] ISO 8601 formatted date
+        def publication_date_start
+          techmd('ndnp:startDate')
+        end
+
+        # End Date (optional)
+        # @return [String] ISO 8601 formatted date
+        def publication_date_end
+          techmd('ndnp:endDate')
+        end
+
+        private
+
+          def load_doc
+            @doc = @parent.doc unless @parent.nil?
+            @doc = Nokogiri::XML(File.open(path)) if @doc.nil?
+          end
+
+          def techmd(spec = nil)
+            base = xpath('//ndnp:reelTechMD')
+            return base if spec.nil?
+            base.xpath(spec).first.text
+          end
+      end
+    end
+  end
+end

--- a/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
+++ b/lib/newspaper_works/ingest/ndnp/issue_ingest.rb
@@ -60,6 +60,18 @@ module NewspaperWorks
           )
         end
 
+        def container_path
+          reel_dir = File.expand_path('..', File.dirname(path))
+          reel_base = File.basename(reel_dir)
+          File.join(reel_dir, "#{reel_base}_1.xml")
+        end
+
+        def container
+          reel_path = container_path
+          return unless File.exist?(reel_path)
+          NewspaperWorks::Ingest::NDNP::ContainerIngest.new(reel_path)
+        end
+
         private
 
           def load_doc

--- a/lib/newspaper_works/ingest/ndnp/ndnp_mets_helper.rb
+++ b/lib/newspaper_works/ingest/ndnp/ndnp_mets_helper.rb
@@ -7,8 +7,11 @@ module NewspaperWorks
       module NDNPMetsHelper
         XML_NS = {
           mets: 'http://www.loc.gov/METS/',
+          METS: 'http://www.loc.gov/METS/',
           mods: 'http://www.loc.gov/mods/v3',
-          MODS: 'http://www.loc.gov/mods/v3'
+          MODS: 'http://www.loc.gov/mods/v3',
+          ndnp: 'http://www.loc.gov/ndnp',
+          NDNP: 'http://www.loc.gov/ndnp'
         }.freeze
 
         # DRY XPath without repeatedly specifying default namespace urlmap

--- a/lib/newspaper_works/ingest/ndnp/page_metadata.rb
+++ b/lib/newspaper_works/ingest/ndnp/page_metadata.rb
@@ -45,16 +45,17 @@ module NewspaperWorks
           detail.xpath("mods:number", **XML_NS).first.text
         end
 
-        # Mandatory page sequence number, indexical to order in issue.
+        # Page sequence number, indexical to order in issue.
         #   "Number" here is one-indexed positive integer, position in
-        #   issue.
-        # @return [Integer] Page sequence number, positive integer
+        #   issue.  Mandatory for page of issue, nil for page of reel.
+        # @return [Integer,NilClass] Page sequence number, positive integer
         def page_sequence_number
           detail = dmd_node.xpath(
             ".//mods:mods//mods:extent[@unit='pages']",
             **XML_NS
           )
-          detail.xpath("mods:start", **XML_NS).first.text.to_i
+          node = detail.xpath("mods:start", **XML_NS).first
+          node.text.to_i unless node.nil?
         end
 
         # Extract identifier from page ALTO, based on file name.

--- a/spec/lib/newspaper_works/ingest/ndnp/batch_xml_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/batch_xml_ingest_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::BatchXMLIngest do
+  include_context "ndnp fixture setup"
+
+  describe "sample batch" do
+    let(:batch) { described_class.new(batch1) }
+
+    it "gets batch name" do
+      expect(batch.name).to eq 'batch_test'
+    end
+
+    it "gets issue by path" do
+      path = batch.issue_paths[0]
+      issue = batch.get(path)
+      expect(issue).to be_a NewspaperWorks::Ingest::NDNP::IssueIngest
+      expect(issue.path).to eq path
+    end
+
+    it "gets reel/container by path" do
+      path = batch.container_paths[0]
+      container = batch.get(path)
+      expect(container).to be_a NewspaperWorks::Ingest::NDNP::ContainerIngest
+      expect(container.path).to eq path
+    end
+
+    it "enumerates container paths" do
+      reel_ids = batch.container_paths
+      expect(reel_ids).to be_an Array
+      expect(reel_ids.size).to eq 3
+    end
+
+    it "enumerates issue paths" do
+      issue_ids = batch.issue_paths
+      expect(issue_ids).to be_an Array
+      expect(issue_ids.size).to eq 4
+    end
+
+    it "enumerates issues" do
+      issues = batch.issues
+      expect(issues).to be_an Array
+      expect(issues.size).to eq 4
+      expect(issues[0]).to be_a NewspaperWorks::Ingest::NDNP::IssueIngest
+    end
+
+    it "enumerates containers" do
+      reels = batch.containers
+      expect(reels).to be_an Array
+      expect(reels.size).to eq 3
+      expect(reels[0]).to be_a NewspaperWorks::Ingest::NDNP::ContainerIngest
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/ndnp/batch_xml_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/batch_xml_ingest_spec.rb
@@ -37,11 +37,21 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::BatchXMLIngest do
       expect(issue_ids.size).to eq 4
     end
 
-    it "enumerates issues" do
+    it "enumerates issues via method" do
       issues = batch.issues
       expect(issues).to be_an Array
       expect(issues.size).to eq 4
       expect(issues[0]).to be_a NewspaperWorks::Ingest::NDNP::IssueIngest
+    end
+
+    it "makes batch fixed-size enumerable of issues" do
+      expect(batch.size).to eq batch.issue_paths.size
+      issues = batch.to_a # implied .each
+      expect(issues.size).to eq batch.size
+      expect(issues.size).to eq 4
+      issues.each do |issue|
+        expect(issue).to be_a NewspaperWorks::Ingest::NDNP::IssueIngest
+      end
     end
 
     it "enumerates containers" do

--- a/spec/lib/newspaper_works/ingest/ndnp/container_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/container_ingest_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::ContainerIngest do
       expect(reel.identifier).to eq reel.metadata.reel_number
     end
 
-    it "gets page by dmdid" do
+    it "gets control image as PageIngest, by dmdid" do
       page = reel.page_by_dmdid('targetModsBib1')
       expect(page).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
       expect(page.dmdid).to eq 'targetModsBib1'
@@ -27,17 +27,18 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::ContainerIngest do
       expect(page.doc).to be reel.doc
     end
 
-    it "enumerates expected pages" do
+    it "enumerates expected issues" do
       # enumerate by casting reel to Array
-      pages = reel.to_a
-      expect(pages.size).to eq 2
-      expect(pages[0]).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+      issues = reel.to_a
+      expect(issues.size).to eq 2
+      expect(issues[0]).to be_a NewspaperWorks::Ingest::NDNP::IssueIngest
+      expect(issues[0].path).to eq reel.issue_paths[0]
     end
 
-    it "gets size, in page count" do
-      pages = reel.to_a
-      expect(reel.size).to eq pages.size
-      expect(reel.size).to eq reel.dmdids.size
+    it "gets size, in issue count" do
+      issues = reel.to_a
+      expect(reel.size).to eq issues.size
+      expect(reel.size).to eq reel.issue_paths.size
     end
   end
 end

--- a/spec/lib/newspaper_works/ingest/ndnp/container_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/container_ingest_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::ContainerIngest do
+  include_context "ndnp fixture setup"
+
+  describe "sample fixture 'batch_test_ver01'" do
+    let(:reel) { described_class.new(reel1) }
+
+    it "gets metadata" do
+      expect(reel.metadata).to be_a \
+        NewspaperWorks::Ingest::NDNP::ContainerMetadata
+      # uses same Nokogiri document context:
+      expect(reel.metadata.doc).to be reel.doc
+      # has identifier method equivalent to reel number
+      expect(reel.identifier).to eq reel.metadata.reel_number
+    end
+
+    it "gets page by dmdid" do
+      page = reel.page_by_dmdid('targetModsBib1')
+      expect(page).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+      expect(page.dmdid).to eq 'targetModsBib1'
+    end
+
+    it "shares xml document context with contained pages" do
+      page = reel.page_by_dmdid('targetModsBib1')
+      expect(page.doc).to be reel.doc
+    end
+
+    it "enumerates expected pages" do
+      # enumerate by casting reel to Array
+      pages = reel.to_a
+      expect(pages.size).to eq 2
+      expect(pages[0]).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
+    end
+
+    it "gets size, in page count" do
+      pages = reel.to_a
+      expect(reel.size).to eq pages.size
+      expect(reel.size).to eq reel.dmdids.size
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/ndnp/container_metadata_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/container_metadata_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'ndnp_shared'
+
+RSpec.describe NewspaperWorks::Ingest::NDNP::ContainerMetadata do
+  include_context "ndnp fixture setup"
+
+  describe "sample fixture 'batch_test_ver01'" do
+    let(:meta) { described_class.new(reel1) }
+
+    it "gets reel_number" do
+      expect(meta.reel_number).to eq "00279557177"
+    end
+
+    it "gets held_by" do
+      expect(meta.held_by).to eq "University of Utah, Salt Lake City, UT"
+    end
+
+    it "gets genre" do
+      expect(meta.genre).to eq 'microfilm'
+    end
+
+    it "gets title" do
+      expect(meta.title).to eq 'Daily national Democrat (Marysville, Calif.)'
+    end
+
+    it "gets start date" do
+      expect(meta.publication_date_start).to eq '1858-08-13'
+    end
+
+    it "gets end date" do
+      expect(meta.publication_date_end).to eq '1858-12-31'
+    end
+  end
+end

--- a/spec/lib/newspaper_works/ingest/ndnp/issue_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/issue_ingest_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::IssueIngest do
       expect(issue.identifier).to eq issue.metadata.lccn
     end
 
+    it "gets nil container for issue without reel XML" do
+      reel = issue.container
+      expect(reel).to be_nil
+    end
+
     it "gets page by dmdid" do
       page = issue.page_by_dmdid('pageModsBib8')
       expect(page).to be_a NewspaperWorks::Ingest::NDNP::PageIngest
@@ -53,6 +58,12 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::IssueIngest do
 
   describe "sample fixture 'batch_test_ver01'" do
     let(:issue) { described_class.new(issue2) }
+
+    it "gets a ContainerIngest for reel providing issue" do
+      reel = issue.container
+      expect(reel).to be_a NewspaperWorks::Ingest::NDNP::ContainerIngest
+      expect(reel.path).to end_with '_1.xml'
+    end
 
     it "gets metadata" do
       expect(issue.metadata).to be_a NewspaperWorks::Ingest::NDNP::IssueMetadata

--- a/spec/lib/newspaper_works/ingest/ndnp/page_ingest_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/page_ingest_spec.rb
@@ -51,4 +51,18 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::PageIngest do
       check_expected_files(page, ['tif', 'jp2', 'pdf', 'xml'])
     end
   end
+
+  describe "sample fixture reel xml" do
+    let(:page) { described_class.new(reel1, 'targetModsBib1') }
+
+    it "gets metadata" do
+      expect(page.metadata).to be_a NewspaperWorks::Ingest::NDNP::PageMetadata
+      # uses same Nokogiri document context:
+      expect(page.metadata.doc).to be page.doc
+    end
+
+    it "gets expected files" do
+      check_expected_files(page, ['tif', 'jp2', 'pdf', 'xml'])
+    end
+  end
 end

--- a/spec/lib/newspaper_works/ingest/ndnp/page_metadata_spec.rb
+++ b/spec/lib/newspaper_works/ingest/ndnp/page_metadata_spec.rb
@@ -57,4 +57,28 @@ RSpec.describe NewspaperWorks::Ingest::NDNP::PageMetadata do
       expect(page.identifier).to eq "././0225.tif"
     end
   end
+
+  describe "sample fixture via Reel XML" do
+    let(:page) { described_class.new(reel1, nil, 'targetModsBib1') }
+
+    it "returns nil page number for page without one" do
+      expect(page.page_number).to eq nil
+    end
+
+    it "gets expected sequence number as Integer" do
+      expect(page.page_sequence_number).to eq nil
+    end
+
+    it "gets expected width from ALTO as Integer " do
+      expect(page.width).to eq 30_176
+    end
+
+    it "gets expected height from ALTO as Integer " do
+      expect(page.height).to eq 29_152
+    end
+
+    it "gets identifier from ALTO as primary file name" do
+      expect(page.identifier).to eq "./0001.tif"
+    end
+  end
 end

--- a/spec/ndnp_shared.rb
+++ b/spec/ndnp_shared.rb
@@ -20,4 +20,11 @@ RSpec.shared_context "ndnp fixture setup", shared_context: :metadata do
       'batch_test_ver01/data/sn85025202/00279557281/1857021401/1857021401.xml'
     )
   end
+
+  let(:reel1) do
+    File.join(
+      ndnp_fixture_path,
+      'batch_test_ver01/data/sn84038814/00279557177/00279557177.xml'
+    )
+  end
 end

--- a/spec/ndnp_shared.rb
+++ b/spec/ndnp_shared.rb
@@ -27,4 +27,11 @@ RSpec.shared_context "ndnp fixture setup", shared_context: :metadata do
       'batch_test_ver01/data/sn84038814/00279557177/00279557177.xml'
     )
   end
+
+  let(:batch1) do
+    File.join(
+      ndnp_fixture_path,
+      'batch_test_ver01/data/BATCH_1.xml'
+    )
+  end
 end


### PR DESCRIPTION
Supercedes PR #130, which was closed to make some changes to component design.  Implements functionality described in #116. 

## New classes:
* `NewspaperWorks::Ingest::NDNP::ContainerMetadata` (reel metadata), accessed via...
* `NewspaperWorks::Ingest::NDNP::ContainerIngest` (reel enumeration of *issues*, access to metadata, incidental ability to enumerate control images as PageIngest)
* `NewspaperWorks::Ingest::NDNP::BatchXMLIngest` (enumeration of batch paths for issues, reels, respectively)

## Modifications to existing classes:
* `NewspaperWorks::Ingest::NDNP::PageMetadata` modified to also work with reel XML source _(only used for control images)_.
* `NewspaperWorks::Ingest::NDNP::PageIngest` modified to also work with reel XML source _(only used for control images)_.