### PR TITLE
TravisCI Ruby and Rails matrix version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ env:
   # It should be sufficient to test only the latest of the patch versions for a minor version, they
   # should be compatible across patch versions (only bug fixes are released in patch versions).
   matrix:
-    - "RAILS_VERSION=5.2.2"
     - "RAILS_VERSION=5.1.7"
+    - "RAILS_VERSION=5.0.7"
 
 services:
   - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - sudo wget -q -O /etc/ImageMagick-6/policy.xml https://raw.githubusercontent.com/marriott-library/newspaper_works/7052ff3bf58022572870a0720d8c5a705090a833/config/vendor/imagemagick-6-policy.xml
   - sudo wget -q -O /opt/install/fits-1.3.0/xml/fits.xml https://gist.githubusercontent.com/brianmcbride/af3fb21fb50a1331d84eca9a9a170f8f/raw/ebb1a285726e4f5c2309b4f6eceed29fa1369538/fits.xml
 rvm:
-  - 2.5.3
+  - 2.5.5
 
 env:
   global:
@@ -44,8 +44,8 @@ env:
   # It should be sufficient to test only the latest of the patch versions for a minor version, they
   # should be compatible across patch versions (only bug fixes are released in patch versions).
   matrix:
-    - "RAILS_VERSION=5.1.6"
-    - "RAILS_VERSION=5.0.7"
+    - "RAILS_VERSION=5.2.2"
+    - "RAILS_VERSION=5.1.7"
 
 services:
   - redis

--- a/newspaper_works.gemspec
+++ b/newspaper_works.gemspec
@@ -24,7 +24,7 @@ SUMMARY
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.add_dependency 'blacklight_iiif_search'
   spec.add_dependency 'blacklight_advanced_search', '6.4.1'
-  spec.add_dependency 'hyrax', '2.5'
+  spec.add_dependency 'hyrax', '2.5.1'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'rails', '~> 5.0'
   spec.add_dependency 'rtesseract', '~> 2.2.0'


### PR DESCRIPTION
Updated the following to the TravisCI configuration:

- Ruby version 2.5.5
- Rails 5.0.7 & 5.1.6 to 5.0.7 & 5.1.7