### PR TITLE
publication_date sort field added

### DIFF
--- a/app/indexers/concerns/newspaper_works/indexes_relationships.rb
+++ b/app/indexers/concerns/newspaper_works/indexes_relationships.rb
@@ -54,7 +54,7 @@ module NewspaperWorks
       solr_doc['issue_id_ssi'] = newspaper_issue.id
       solr_doc['issue_title_ssi'] = newspaper_issue.title.first
       if newspaper_issue.publication_date.present?
-        solr_doc['issue_pubdate_dtsi'] = "#{newspaper_issue.publication_date}T00:00:00Z"
+        solr_doc['publication_date_dtsim'] ||= ["#{newspaper_issue.publication_date}T00:00:00Z"]
       end
       solr_doc['issue_volume_ssi'] = newspaper_issue.volume
       solr_doc['issue_edition_number_ssi'] = newspaper_issue.edition_number || '1'

--- a/app/presenters/hyrax/newspaper_article_presenter.rb
+++ b/app/presenters/hyrax/newspaper_article_presenter.rb
@@ -13,7 +13,7 @@ module Hyrax
              :genre, to: :solr_document
 
     def publication_date
-      solr_document["publication_date_dtsim"]
+      solr_document["publication_date_dtsim"]&.first
     end
 
     def page_ids

--- a/app/presenters/hyrax/newspaper_page_presenter.rb
+++ b/app/presenters/hyrax/newspaper_page_presenter.rb
@@ -51,8 +51,8 @@ module Hyrax
       end
 
       def issue_date_for_url
-        return nil unless solr_document['issue_pubdate_dtsi']
-        solr_document['issue_pubdate_dtsi'].match(/\A[\d]{4}-[\d]{2}-[\d]{2}/).to_s
+        return nil unless publication_date
+        publication_date.match(/\A[\d]{4}-[\d]{2}-[\d]{2}/).to_s
       end
 
       def edition_for_url

--- a/app/presenters/hyrax/newspaper_title_presenter.rb
+++ b/app/presenters/hyrax/newspaper_title_presenter.rb
@@ -11,7 +11,7 @@ module Hyrax
     end
 
     def front_page_search_params
-      { f: { "publication_title_ssi" => title, "first_page_bsi" => [true] } }
+      { f: { "publication_title_ssi" => title, "first_page_bsi" => [true] }, sort: 'publication_date_dtsim asc' }
     end
 
     def issues

--- a/app/presenters/newspaper_works/issue_info_presenter.rb
+++ b/app/presenters/newspaper_works/issue_info_presenter.rb
@@ -10,8 +10,8 @@ module NewspaperWorks
       solr_document['issue_title_ssi']
     end
 
-    def issue_pubdate
-      solr_document['issue_pubdate_dtsi']
+    def publication_date
+      solr_document['publication_date_dtsim']&.first
     end
 
     def issue_volume

--- a/lib/generators/newspaper_works/install_generator.rb
+++ b/lib/generators/newspaper_works/install_generator.rb
@@ -58,7 +58,7 @@ module NewspaperWorks
       return if IO.read('app/controllers/catalog_controller.rb').include?('include BlacklightAdvancedSearch::Controller')
       say_status('info', 'INSTALLING BLACKLIGHT ADVANCED SEARCH', :blue)
       search_form_path = 'app/views/catalog/_search_form.html.erb'
-      existing_search_form = File.exists?(search_form_path) ? true : false
+      existing_search_form = File.exist?(search_form_path) ? true : false
       generate 'blacklight_advanced_search:install', '--force'
       remove_file search_form_path unless existing_search_form
     end
@@ -102,6 +102,15 @@ module NewspaperWorks
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    def add_pubdate_sort_to_catalog_controller
+      marker = 'config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"'
+      inject_into_file 'app/controllers/catalog_controller.rb', after: marker do
+        "\n\n    # NewspaperWorks sort fields\n"\
+        '    config.add_sort_field "publication_date_dtsim desc", label: "publication date \u25BC"
+    config.add_sort_field "publication_date_dtsim asc", label: "publication date \u25B2"'
+      end
+    end
 
     def inject_configuration
       copy_file 'config/initializers/newspaper_works.rb'

--- a/lib/generators/newspaper_works/templates/config/initializers/patch_blacklight_advanced_search.rb
+++ b/lib/generators/newspaper_works/templates/config/initializers/patch_blacklight_advanced_search.rb
@@ -32,7 +32,7 @@ class BlacklightAdvancedSearch::QueryParser
                 else
                   params[:date_end] + '-12-31T23:59:59.999Z'
                 end
-    '(issue_pubdate_dtsi:[' + range_start + ' TO ' + range_end + '])'
+    '(publication_date_dtsim:[' + range_start + ' TO ' + range_end + '])'
   end
 end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CatalogController do
       expect(subject['genre_sim'].label).to eq('Article type')
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it 'has definitions for non-displaying facet fields' do
       expect(subject['place_of_publication_label_sim']).not_to be_falsey
       expect(subject['issn_sim']).not_to be_falsey
@@ -24,7 +23,15 @@ RSpec.describe CatalogController do
       expect(subject['preceded_by_sim']).not_to be_falsey
       expect(subject['succeeded_by_sim']).not_to be_falsey
     end
-    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe 'NewspaperWorks::InstallGenerator#add_pubdate_sort_to_catalog_controller' do
+    subject { described_class.blacklight_config.sort_fields }
+
+    it 'has NewspaperWorks sort fields' do
+      expect(subject['publication_date_dtsim asc'].class).to eq Blacklight::Configuration::SortField
+      expect(subject['publication_date_dtsim desc'].field).to eq 'publication_date_dtsim desc'
+    end
   end
 
   describe 'NewspaperWorks::BlacklightAdvancedSearchGenerator' do

--- a/spec/indexers/concerns/newspaper_works/indexes_relationships_spec.rb
+++ b/spec/indexers/concerns/newspaper_works/indexes_relationships_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe NewspaperWorks::IndexesRelationships do
       expect(solr_doc['issue_id_ssi']).not_to be_falsey
       expect(solr_doc['issue_title_ssi']).to eq('December 7, 1941')
       expect(solr_doc['issue_edition_number_ssi']).to eq('1')
+      expect(solr_doc['publication_date_dtsim'].first).to eq('1941-12-07T00:00:00Z')
     end
   end
 

--- a/spec/model_shared.rb
+++ b/spec/model_shared.rb
@@ -79,6 +79,7 @@ def model_fixtures(target_type)
   publication.lccn = 'sn1234567'
   issue1 = NewspaperIssue.new
   issue1.title = ['December 7, 1941']
+  issue1.publication_date = '1941-12-07'
   issue1.resource_type = ["newspaper"]
   issue1.language = ["eng"]
   issue1.held_by = "Marriott Library"

--- a/spec/presenters/hyrax/newspaper_page_presenter_spec.rb
+++ b/spec/presenters/hyrax/newspaper_page_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::NewspaperPagePresenter do
       "width" => "800px",
       "issue_id_ssi" => "issue1",
       "issue_edition_number_ssi" => '1',
-      "issue_pubdate_dtsi" => "2017-08-25T00:00:00Z",
+      "publication_date_dtsim" => ["2017-08-25T00:00:00Z"],
       "publication_unique_id_ssi" => "sn1234567",
       'is_following_page_of_ssi' => 'foo',
       'is_preceding_page_of_ssi' => 'bar',

--- a/spec/presenters/hyrax/newspaper_title_presenter_spec.rb
+++ b/spec/presenters/hyrax/newspaper_title_presenter_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Hyrax::NewspaperTitlePresenter do
     subject { presenter.front_page_search_params }
     it 'will return solr query parameters for locating every first page associated with the title' do
       expect(subject).to contain_exactly([:f, "publication_title_ssi" => ["Wall Street Journal"],
-                                              "first_page_bsi" => [true]])
+                                              "first_page_bsi" => [true]],
+                                         [:sort, "publication_date_dtsim asc"])
     end
   end
 

--- a/spec/presenters/newspaper_works/issue_info_presenter_spec.rb
+++ b/spec/presenters/newspaper_works/issue_info_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NewspaperWorks::IssueInfoPresenter do
     {
       'issue_id_ssi' => 'foo',
       'issue_title_ssi' => 'bar',
-      'issue_pubdate_dtsi' => 'baz',
+      'publication_date_dtsim' => ['baz'],
       'issue_volume_ssi' => 'quux',
       'issue_edition_number_ssi' => '123',
       'issue_number_ssi' => '456'
@@ -25,9 +25,9 @@ RSpec.describe NewspaperWorks::IssueInfoPresenter do
     end
   end
 
-  describe '#issue_pubdate' do
+  describe '#publication_date' do
     it 'returns the correct value' do
-      expect(subject.issue_pubdate).to eq 'baz'
+      expect(subject.publication_date).to eq 'baz'
     end
   end
 


### PR DESCRIPTION
* Adds a sort field to the search results page to allow users to sort results by the issue publication date
* Make publication date the default sort for 'view all front pages' link in NewspaperTitle#show view 
* Change `issue_pubdate_dtsi` field to `publication_date_dtsim` for NewspaperPage to match how publication date is indexed for NewspaperIssue and NewspaperArticle