### PR TITLE
Opt-in RSpec CSV logging formatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,22 @@ module EngineRoutes
   end
 end
 
+class CSVLoggingFormatter < RSpec::Core::Formatters::JsonFormatter
+  RSpec::Core::Formatters.register self
+
+  def close(_notification)
+    with_headers = {
+      write_headers: true,
+      headers: ['Example', 'Status', 'Run Time', 'Exception']
+    }
+    CSV.open(output.path, 'w', with_headers) do |csv|
+      @output_hash[:examples].map do |ex|
+        csv << [ex[:full_description], ex[:status], ex[:run_time], ex[:exception]]
+      end
+    end
+  end
+end
+
 RSpec.configure do |config|
   # enable FactoryBot:
   require 'factory_bot'
@@ -210,6 +226,9 @@ RSpec.configure do |config|
   # (e.g. via a command-line flag).
   #  config.default_formatter = "doc"
   # end
+
+  # opt-in CSV logging formatter, set SPEC_CSV environment variable to use:
+  config.add_formatter(CSVLoggingFormatter, 'spec_log.csv') unless ENV['SPEC_CSV'].nil?
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
This allows one to opt-in, only by explicitly setting a `SPEC_CSV=1` environment variable, to directing CSV-formatted output of RSpec to a `spec_log.csv` file instead of outputting progress to stdout.

Travis passed for this branch, and this should be low risk, because it is not enabled in any way by default — it must be opted in by the developer looking to time test results (e.g. `SPEC_CSV=1 bundle exec rspec`).